### PR TITLE
xCertificateExport: Fixed bug causing pfx export with matchsource enabled to fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- xCertificateExport:
+  - Fixed bug causing pfx export with matchsource enabled to fail
 - Added `Documentation and Examples` section to Readme.md file - see
   [issue #98](https://github.com/PowerShell/xCertificate/issues/98).
 - Changed description in Credential parameter of xPfxImport resource

--- a/Modules/xCertificate/DSCResources/MSFT_xCertificateExport/MSFT_xCertificateExport.psm1
+++ b/Modules/xCertificate/DSCResources/MSFT_xCertificateExport/MSFT_xCertificateExport.psm1
@@ -443,7 +443,7 @@ function Test-TargetResource
                 }
                 elseif ($Type -eq 'PFX')
                 {
-                    $exportedCertificate.Import($Path, $Password, [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::PersistKeySet)
+                    $exportedCertificate.Import($Path, $Password.Password, [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::PersistKeySet)
                 } # if
 
                 if ($certificateThumbprintToExport -notin $exportedCertificate.Thumbprint)

--- a/Tests/Integration/MSFT_xCertificateExport.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xCertificateExport.Integration.Tests.ps1
@@ -38,9 +38,8 @@ try
         $script:pfxPath = Join-Path -Path $env:Temp -ChildPath 'xCertificateExportTestCert.pfx'
         $null = Remove-Item -Path $script:pfxPath -Force -ErrorAction SilentlyContinue
         $pfxPlainTextPassword = 'P@ssword!1'
-        $pfxPassword = ConvertTo-SecureString -String $pfxPlainTextPassword -AsPlainText -Force
         $pfxCredential = New-Object -TypeName System.Management.Automation.PSCredential `
-            -ArgumentList ('Dummy',$pfxPassword)
+            -ArgumentList ('Dummy',(ConvertTo-SecureString -String $pfxPlainTextPassword -AsPlainText -Force))
 
         # Generate the Valid certificate for testing
         $certificateDNSNames = @('www.fabrikam.com', 'www.contoso.com')
@@ -149,7 +148,7 @@ try
 
             It 'Should have set the resource and the thumbprint of the exported certificate should match' {
                 $exportedCertificate = New-Object -TypeName 'System.Security.Cryptography.X509Certificates.X509Certificate2Collection'
-                $exportedCertificate.Import($script:certificatePath,$pfxPassword,[System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::PersistKeySet)
+                $exportedCertificate.Import($script:certificatePath,$pfxCredential.Password,[System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::PersistKeySet)
                 $exportedCertificate[0].Thumbprint | Should -Be $script:validCertificateThumbprint
             }
         }


### PR DESCRIPTION
**Pull Request (PR) description**
Fixed pfx import check when matchsource is enabled to use a securestring instead of attempting to use a credential object.
Also updated integration test to make this less likely to happen again (now just creating a plaintext  password and a credential variable as used in the DSC resource itself).

**This Pull Request (PR) fixes the following issues:**
#116

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xcertificate/117)
<!-- Reviewable:end -->
