### PR TITLE
Remove Path requirement for PFXImport when Absent - Fixes #136

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
   - Refactored to remove code duplication by creating Get-CertificateStorePath.
   - Improved unit tests to meet standards and provide better coverage.
   - Improved integration tests to meet standards and provide better coverage.
+  - Changed Path parameter to be optional to fix error when ensuring certificate
+    is absent and certificate file does not exist on disk - fixes [Issue #136](https://github.com/PowerShell/CertificateDsc/issues/136).
+  - Removed ShouldProcess because it is not required by DSC Resources.
+  - Minor style corrections.
+  - Changed unit tests to be non-destructive.
+  - Improved naming and description of example files.
 - CertificateDsc.Common:
   - Corrected to meet style guidelines.
   - Added function Get-CertificateStorePath for generating Certificate Store path.

--- a/Modules/CertificateDsc/DSCResources/MSFT_PfxImport/MSFT_PfxImport.schema.mof
+++ b/Modules/CertificateDsc/DSCResources/MSFT_PfxImport/MSFT_PfxImport.schema.mof
@@ -2,7 +2,7 @@
 class MSFT_PfxImport : OMI_BaseResource
 {
     [Key,Description("The thumbprint (unique identifier) of the PFX file you're importing.")] string Thumbprint;
-    [Required,Description("The path to the PFX file you want to import.")] string Path;
+    [Write,Description("The path to the PFX file you want to import.")] string Path;
     [Key,Description("The Windows Certificate Store Location to import the PFX file to."),ValueMap{"LocalMachine", "CurrentUser"},Values{"LocalMachine", "CurrentUser"}] string Location;
     [Key,Description("The Windows Certificate Store Name to import the PFX file to.")] string Store;
     [write,Description("Determines whether the private key is exportable from the machine after it has been imported")] boolean Exportable;

--- a/Modules/CertificateDsc/DSCResources/MSFT_PfxImport/en-US/MSFT_PfxImport.strings.psd1
+++ b/Modules/CertificateDsc/DSCResources/MSFT_PfxImport/en-US/MSFT_PfxImport.strings.psd1
@@ -7,8 +7,7 @@ ConvertFrom-StringData @'
     SettingPfxStatusMessage = Setting Pfx '{0}' existence in '{1}'.
     ImportingPfxMessage = Importing Pfx '{0}' into '{1}'.
     RemovingPfxMessage = Removing Pfx '{0}' from '{1}'.
-
     CertificateStoreNotFoundError = Certificate Store '{0}' not found.
-
+    CertificatePfxFileNotFoundError = Certificate Pfx file '{0}' not found.
     ImportingPfxShould = Importing Pfx '{0}' into '{1}'
 '@

--- a/Modules/CertificateDsc/Examples/Resources/PfxImport/1-InstallPFXForWebSite.ps1
+++ b/Modules/CertificateDsc/Examples/Resources/PfxImport/1-InstallPFXForWebSite.ps1
@@ -1,6 +1,7 @@
 <#
     .EXAMPLE
-    Import a PFX into the WebHosting store and bind it to an IIS Web Site.
+    Import a PFX into the 'WebHosting' Local Machine certificate store and
+    bind it to an IIS Web Site.
 #>
 Configuration Example
 {

--- a/Modules/CertificateDsc/Examples/Resources/PfxImport/2-InstallPFX.ps1
+++ b/Modules/CertificateDsc/Examples/Resources/PfxImport/2-InstallPFX.ps1
@@ -1,0 +1,32 @@
+<#
+    .EXAMPLE
+    Import a PFX into the 'My' Local Machine certificate store.
+#>
+Configuration Example
+{
+    param
+    (
+        [Parameter()]
+        [System.String[]]
+        $NodeName = 'localhost',
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullorEmpty()]
+        [System.Management.Automation.PSCredential]
+        $Credential
+    )
+
+    Import-DscResource -ModuleName CertificateDsc
+
+    Node $AllNodes.NodeName
+    {
+        PfxImport CompanyCert
+        {
+            Thumbprint = 'c81b94933420221a7ac004a90242d8b1d3e5070d'
+            Path       = '\\Server\Share\Certificates\CompanyCert.pfx'
+            Location   = 'LocalMachine'
+            Store      = 'My'
+            Credential = $Credential
+        }
+    }
+}

--- a/Modules/CertificateDsc/Examples/Resources/PfxImport/3-RemovePFX.ps1
+++ b/Modules/CertificateDsc/Examples/Resources/PfxImport/3-RemovePFX.ps1
@@ -1,6 +1,6 @@
 <#
     .EXAMPLE
-    Import a PFX into the My store.
+    Remove a PFX certificate from the 'My' Local Machine certificate store.
 #>
 Configuration Example
 {
@@ -23,10 +23,10 @@ Configuration Example
         PfxImport CompanyCert
         {
             Thumbprint = 'c81b94933420221a7ac004a90242d8b1d3e5070d'
-            Path       = '\\Server\Share\Certificates\CompanyCert.pfx'
             Location   = 'LocalMachine'
             Store      = 'My'
             Credential = $Credential
+            Ensure     = 'Absent'
         }
     }
 }

--- a/Tests/Integration/MSFT_PfxImport.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_PfxImport.Integration.Tests.ps1
@@ -23,10 +23,12 @@ $TestEnvironment = Initialize-TestEnvironment `
 # Using try/finally to always cleanup even if something awful happens.
 try
 {
-    # Generate a self-signed certificate, export it and remove it from the store
-    # to use for testing.
-    # Don't use CurrentUser certificates for this test because they won't be found because
-    # DSC LCM runs under a different context (Local System).
+    <#
+        Generate a self-signed certificate, export it and remove it from the store
+        to use for testing.
+        Don't use CurrentUser certificates for this test because they won't be found because
+        DSC LCM runs under a different context (Local System).
+    #>
     $certificate = New-SelfSignedCertificate `
         -DnsName $env:ComputerName `
         -CertStoreLocation Cert:\LocalMachine\My
@@ -209,7 +211,6 @@ try
                 {
                     & "$($script:DSCResourceName)_Remove_Config" `
                         -OutputPath $TestDrive `
-                        -Path $pfxPath `
                         -Thumbprint $certificate.Thumbprint
 
                     Start-DscConfiguration `

--- a/Tests/Integration/MSFT_PfxImport_remove.config.ps1
+++ b/Tests/Integration/MSFT_PfxImport_remove.config.ps1
@@ -8,7 +8,6 @@ Configuration MSFT_PfxImport_Remove_Config {
     node localhost {
         PfxImport Integration_Test {
             Thumbprint = $Thumbprint
-            Path       = $Path
             Location   = 'LocalMachine'
             Store      = 'My'
             Ensure     = 'Absent'

--- a/Tests/Unit/MSFT_PfxImport.Tests.ps1
+++ b/Tests/Unit/MSFT_PfxImport.Tests.ps1
@@ -4,6 +4,9 @@ param ()
 $script:DSCModuleName      = 'CertificateDsc'
 $script:DSCResourceName    = 'MSFT_PfxImport'
 
+# Load the common test helper
+Import-Module -Name (Join-Path -Path (Join-Path -Path (Split-Path $PSScriptRoot -Parent) -ChildPath 'TestHelpers') -ChildPath 'CommonTestHelper.psm1') -Global
+
 #region HEADER
 # Integration Test Template Version: 1.1.0
 [String] $script:moduleRoot = Join-Path -Path $(Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))) -ChildPath 'Modules\CertificateDsc'
@@ -56,7 +59,22 @@ try
             HasPrivateKey = $false
         }
 
-        $PresentParams = @{
+        $testCertificatePath_parameterfilter = {
+            $Path -eq $validPath
+        }
+
+        $testGetChildItem_parameterfilter = {
+            $Path -eq $validCertFullPath
+        }
+
+        $importPfxCertificate_parameterfilter = {
+            $CertStoreLocation -eq $validCertPath -and `
+            $FilePath -eq $validPath -and `
+            $Exportable -eq $True -and `
+            $Password -eq $testCredential.Password
+        }
+
+        $presentParams = @{
             Thumbprint = $validThumbprint
             Path       = $validPath
             Ensure     = 'Present'
@@ -67,9 +85,8 @@ try
             Verbose    = $True
         }
 
-        $AbsentParams = @{
+        $absentParams = @{
             Thumbprint = $validThumbprint
-            Path       = $validPath
             Ensure     = 'Absent'
             Location   = 'LocalMachine'
             Store      = 'My'
@@ -77,19 +94,22 @@ try
         }
 
         Describe "$DSCResourceName\Get-TargetResource" {
-            $null | Set-Content -Path $validPath
+            Context 'When the PFX file exists and the certificate exists with a private key' {
+                Mock `
+                    -CommandName Test-CertificatePath `
+                    -MockWith {
+                        $true
+                    } `
+                    -ParameterFilter $testCertificatePath_parameterfilter
 
-            Context 'When the certificate exists with a private key' {
                 Mock `
                     -CommandName Get-ChildItem `
                     -MockWith {
                         $validCertificateWithPrivateKey
                     } `
-                    -ParameterFilter {
-                        $Path -eq $validCertFullPath
-                    }
+                    -ParameterFilter $testGetChildItem_parameterfilter
 
-                $result = Get-TargetResource @PresentParams
+                $result = Get-TargetResource @presentParams
 
                 It 'Should return a hashtable' {
                     $result | Should -BeOfType System.Collections.Hashtable
@@ -103,25 +123,33 @@ try
 
                 It 'Should call the expected mocks' {
                     Assert-MockCalled `
+                        -CommandName Test-CertificatePath `
+                        -ParameterFilter $testCertificatePath_parameterfilter `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled `
                         -CommandName Get-ChildItem `
-                        -ParameterFilter { $Path -eq $validCertFullPath } `
+                        -ParameterFilter $testGetChildItem_parameterfilter `
                         -Exactly -Times 1
                 }
             }
 
-            Context 'When the certificate exists without private key' {
+            Context 'When the PFX file exists and the certificate exists without private key' {
+                Mock `
+                    -CommandName Test-CertificatePath `
+                    -MockWith {
+                        $true
+                    } `
+                    -ParameterFilter $testCertificatePath_parameterfilter
+
                 Mock `
                     -CommandName Get-ChildItem `
                     -MockWith {
                         $validCertificateWithoutPrivateKey
                     } `
-                    -ParameterFilter {
-                        $Path -eq $validCertFullPath
-                    }
+                    -ParameterFilter $testGetChildItem_parameterfilter
 
-                $null | Set-Content -Path $validPath
-
-                $result = Get-TargetResource @PresentParams
+                $result = Get-TargetResource @presentParams
 
                 It 'Should return a hashtable' {
                     $result | Should -BeOfType System.Collections.Hashtable
@@ -135,18 +163,30 @@ try
 
                 It 'Should call the expected mocks' {
                     Assert-MockCalled `
+                        -CommandName Test-CertificatePath `
+                        -ParameterFilter $testCertificatePath_parameterfilter `
+                        -Exactly -Times 1
+
+                    Assert-MockCalled `
                         -CommandName Get-ChildItem `
-                        -ParameterFilter { $Path -eq $validCertFullPath } `
+                        -ParameterFilter $testGetChildItem_parameterfilter `
                         -Exactly -Times 1
                 }
             }
 
-            Context 'When the certificate does not exist' {
-                Mock -CommandName Get-ChildItem
+            Context 'When the PFX file exists and the certificate does not exist' {
+                Mock `
+                    -CommandName Test-CertificatePath `
+                    -MockWith {
+                        $true
+                    } `
+                    -ParameterFilter $testCertificatePath_parameterfilter
 
-                $null | Set-Content -Path $validPath
+                Mock `
+                    -CommandName Get-ChildItem `
+                    -ParameterFilter $testGetChildItem_parameterfilter
 
-                $result = Get-TargetResource @PresentParams
+                $result = Get-TargetResource @presentParams
 
                 It 'Should return a hashtable' {
                     $result | Should -BeOfType System.Collections.Hashtable
@@ -160,17 +200,94 @@ try
 
                 It 'Should call the expected mocks' {
                     Assert-MockCalled `
+                        -CommandName Test-CertificatePath `
+                        -ParameterFilter $testCertificatePath_parameterfilter `
+                        -Exactly -Times 1
+
+                     Assert-MockCalled `
                         -CommandName Get-ChildItem `
+                        -ParameterFilter $testGetChildItem_parameterfilter `
+                        -Exactly -Times 1
+                }
+            }
+
+            Context 'When the PFX file does not exist and ensure is absent' {
+                Mock `
+                    -CommandName Test-CertificatePath `
+                    -MockWith {
+                        $false
+                    } `
+                    -ParameterFilter $testCertificatePath_parameterfilter
+
+                Mock `
+                    -CommandName Get-ChildItem `
+                    -MockWith {
+                        $validCertificateWithoutPrivateKey
+                    } `
+                    -ParameterFilter $testGetChildItem_parameterfilter
+
+                $result = Get-TargetResource @absentParams
+
+                It 'Should return a hashtable' {
+                    $result | Should -BeOfType System.Collections.Hashtable
+                }
+
+                It 'Should contain the input values' {
+                    $result.Thumbprint | Should -BeExactly $validThumbprint
+                    $result.Ensure | Should -BeExactly 'Absent'
+                }
+
+                It 'Should call the expected mocks' {
+                    Assert-MockCalled `
+                        -CommandName Test-CertificatePath `
+                        -ParameterFilter $testCertificatePath_parameterfilter `
+                        -Exactly -Times 0
+
+                    Assert-MockCalled `
+                        -CommandName Get-ChildItem `
+                        -ParameterFilter $testGetChildItem_parameterfilter `
+                        -Exactly -Times 1
+                }
+            }
+
+            Context 'When the PFX file does not exist and ensure is present' {
+                Mock `
+                    -CommandName Test-CertificatePath `
+                    -MockWith {
+                        $false
+                    } `
+                    -ParameterFilter $testCertificatePath_parameterfilter
+
+                It 'Should throw expected exception' {
+                    $errorRecord = Get-InvalidArgumentRecord `
+                        -Message ($LocalizedData.CertificatePfxFileNotFoundError -f $validPath) `
+                        -ArgumentName 'Path'
+
+                    {
+                        $script:result = Get-TargetResource @presentParams
+                    } | Should -Throw $errorRecord
+                }
+
+                It 'Should call the expected mocks' {
+                    Assert-MockCalled `
+                        -CommandName Test-CertificatePath `
+                        -ParameterFilter $testCertificatePath_parameterfilter `
                         -Exactly -Times 1
                 }
             }
         }
 
         Describe "$DSCResourceName\Test-TargetResource" {
-            $null | Set-Content -Path $validPath
-
             It 'Should return a bool' {
-                Test-TargetResource @PresentParams | Should -BeOfType Boolean
+                Mock -CommandName Get-TargetResource {
+                    return @{
+                        Thumbprint = $validThumbprint
+                        Path       = $validPath
+                        Ensure     = 'Absent'
+                    }
+                }
+
+                Test-TargetResource @presentParams | Should -BeOfType Boolean
             }
 
             Context 'When valid path and thumbprint and certificate is not in store but should be' {
@@ -183,7 +300,7 @@ try
                         }
                     }
 
-                    Test-TargetResource @PresentParams | Should -Be $false
+                    Test-TargetResource @presentParams | Should -Be $false
                 }
             }
 
@@ -197,7 +314,7 @@ try
                         }
                     }
 
-                    Test-TargetResource @AbsentParams | Should -Be $true
+                    Test-TargetResource @absentParams | Should -Be $true
                 }
             }
 
@@ -211,7 +328,7 @@ try
                         }
                     }
 
-                    Test-TargetResource @PresentParams | Should -Be $true
+                    Test-TargetResource @presentParams | Should -Be $true
                 }
             }
 
@@ -225,34 +342,26 @@ try
                         }
                     }
 
-                    Test-TargetResource @AbsentParams | Should -Be $false
+                    Test-TargetResource @absentParams | Should -Be $false
                 }
             }
         }
 
         Describe "$DSCResourceName\Set-TargetResource" {
-            $null | Set-Content -Path $validPath
-
-            Context 'When valid path and thumbprint and Ensure is Present' {
-                Mock -CommandName Import-PfxCertificate -ParameterFilter {
-                    $CertStoreLocation -eq $validCertPath -and `
-                    $FilePath -eq $validPath -and `
-                    $Exportable -eq $True -and `
-                    $Password -eq $testCredential.Password
-                }
+            Context 'When PFX file exists and thumbprint and Ensure is Present' {
+                Mock `
+                    -CommandName Import-PfxCertificate `
+                    -ParameterFilter $importPfxCertificate_parameterfilter
                 Mock -CommandName Get-ChildItem
                 Mock -CommandName Remove-Item
 
-                Set-TargetResource @PresentParams
-
+                Set-TargetResource @presentParams
 
                 It 'Should call Import-PfxCertificate with the parameters supplied' {
-                    Assert-MockCalled -CommandName Import-PfxCertificate -Exactly -Times 1 -ParameterFilter {
-                        $CertStoreLocation -eq $validCertPath -and `
-                        $FilePath -eq $validPath -and `
-                        $Exportable -eq $True -and `
-                        $Password -eq $testCredential.Password
-                    }
+                    Assert-MockCalled `
+                        -CommandName Import-PfxCertificate `
+                        -ParameterFilter $importPfxCertificate_parameterfilter `
+                        -Exactly -Times 1
                 }
 
                 It 'Should not call Get-ChildItem' {
@@ -264,17 +373,14 @@ try
                 }
             }
 
-            Context 'When valid path and thumbprint and Ensure is Absent' {
+            Context 'When certificate exists and Ensure is Absent' {
                 Mock -CommandName Import-PfxCertificate
                 Mock -CommandName Get-ChildItem -MockWith {
-                    Get-Item -Path $validPath
-                }
-                Mock -CommandName Where-Object -MockWith {
-                    Get-Item -Path $validPath
+                    @{ Thumbprint = $validThumbprint }
                 }
                 Mock -CommandName Remove-Item
 
-                Set-TargetResource @AbsentParams
+                Set-TargetResource @absentParams
 
                 It 'Should not call Import-PfxCertificate' {
                     Assert-MockCalled -CommandName Import-PfxCertificate -Exactly -Times 0


### PR DESCRIPTION
**Pull Request (PR) description**
- PfxImport:
  - Changed Path parameter to be optional to fix error when ensuring certificate
    is absent and certificate file does not exist on disk - fixes [Issue #136](https://github.com/PowerShell/CertificateDsc/issues/136).
  - Removed ShouldProcess because it is not required by DSC Resources.
  - Minor style corrections.
  - Changed unit tests to be non-destructive.
  - Improved naming and description of example files.

**This Pull Request (PR) fixes the following issues:**
- Fixes #136

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [x] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

@johlju - would you mind reviewing when you have time? I ended up making a few style corrections at the same time.