### PR TITLE
Fix export of PFX with matchsource enabled - Fixes #116

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
   - Validate Example Files To Be Published
   - Validate Markdown Links
   - Relative Path Length
+- CertificateExport:
+  - Fixed bug causing PFX export with matchsource enabled to fail - fixes
+    [Issue 117](https://github.com/PowerShell/CertificateDsc/issues/117)
 
 ## 4.2.0.0
 

--- a/DSCResources/MSFT_CertificateExport/MSFT_CertificateExport.psm1
+++ b/DSCResources/MSFT_CertificateExport/MSFT_CertificateExport.psm1
@@ -443,7 +443,7 @@ function Test-TargetResource
                 }
                 elseif ($Type -eq 'PFX')
                 {
-                    $exportedCertificate.Import($Path, $Password, [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::PersistKeySet)
+                    $exportedCertificate.Import($Path, $Password.GetNetworkCredential().Password, [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::PersistKeySet)
                 } # if
 
                 if ($certificateThumbprintToExport -notin $exportedCertificate.Thumbprint)


### PR DESCRIPTION
#### Pull Request (PR) description

This PR fixes the error that occurs when using the CertificateExport to export a PFX with matchsource enabled. This PR replaces #117 .

#### This Pull Request (PR) fixes the following issues

- Fixes #116 

#### Task list

- [x] Added an entry under the Unreleased section of the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in the resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

@johlju - would you mind reviewing when you get a chance?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/certificatedsc/170)
<!-- Reviewable:end -->
