### PR TITLE
CertReq: Fix X500 Subject Match and Renewal - Fixes #172

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,15 @@
 
 ## Unreleased
 
+- Minor style corrections from PR for [Issue #161](https://github.com/PowerShell/CertificateDsc/issues/161)
+  that were missed.
+
 ## 4.3.0.0
 
-- Updated certificate import to only use Import-CertificateEx - fixes [Issue #161](https://github.com/PowerShell/CertificateDsc/issues/161)
-- Update LICENSE file to match the Microsoft Open Source Team standard -fixes
+- CertificateImport:
+  - Updated certificate import to only use Import-CertificateEx - fixes
+    [Issue #161](https://github.com/PowerShell/CertificateDsc/issues/161).
+- Update LICENSE file to match the Microsoft Open Source Team standard - fixes
   [Issue 164](https://github.com/PowerShell/CertificateDsc/issues/164).
 - Opted into Common Tests - fixes [Issue 168](https://github.com/PowerShell/CertificateDsc/issues/168):
   - Required Script Analyzer Rules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@
 - CertificateExport:
   - Fixed bug causing PFX export with matchsource enabled to fail - fixes
     [Issue 117](https://github.com/PowerShell/CertificateDsc/issues/117)
+- CertReq:
+  - Simplified unit test comparison certificate request strings to make
+    tests easier to read.
+  - Improved unit test layout and updated to meet standards.
+  - Fixed bug in certificate renewal with `RenewalCert` attribute in the
+    incorrect section - fixes [Issue 172](https://github.com/PowerShell/CertificateDsc/issues/172)
 
 ## 4.2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
   - Improved unit test layout and updated to meet standards.
   - Fixed bug in certificate renewal with `RenewalCert` attribute in the
     incorrect section - fixes [Issue 172](https://github.com/PowerShell/CertificateDsc/issues/172)
+  - Fixed bug in certificate renewal when subject contains X500 path that
+    is in a different order - fixes [Issue 173](https://github.com/PowerShell/CertificateDsc/issues/173)
 
 ## 4.2.0.0
 

--- a/DSCResources/MSFT_CertReq/MSFT_CertReq.psm1
+++ b/DSCResources/MSFT_CertReq/MSFT_CertReq.psm1
@@ -442,6 +442,15 @@ KeyUsage = $KeyUsage
 FriendlyName = "$FriendlyName"
 "@
     }
+
+    if ($thumbprint)
+    {
+        $requestDetails += @"
+
+RenewalCert = $Thumbprint
+"@
+    }
+
     $requestDetails += @"
 
 [RequestAttributes]
@@ -466,13 +475,6 @@ CertificateTemplate = "$CertificateTemplate"
 
 [Extensions]
 2.5.29.17 = "{text}$SubjectAltName"
-"@
-    }
-    if ($thumbprint)
-    {
-        $requestDetails += @"
-
-RenewalCert = $Thumbprint
 "@
     }
     Set-Content -Path $infPath -Value $requestDetails

--- a/DSCResources/MSFT_CertificateImport/MSFT_CertificateImport.psm1
+++ b/DSCResources/MSFT_CertificateImport/MSFT_CertificateImport.psm1
@@ -252,8 +252,10 @@ function Set-TargetResource
                 Verbose           = $VerbosePreference
             }
 
-            # Using Import-CertificateEx instead of Import-Certificate due to the following issue:
-            # https://github.com/PowerShell/CertificateDsc/issues/161
+            <#
+                Using Import-CertificateEx instead of Import-Certificate due to the following issue:
+                https://github.com/PowerShell/CertificateDsc/issues/161
+            #>
             Import-CertificateEx @importCertificateParameters
         }
     }

--- a/Tests/Unit/MSFT_CertReq.Tests.ps1
+++ b/Tests/Unit/MSFT_CertReq.Tests.ps1
@@ -474,20 +474,22 @@ OID = $oid
         }
 
         Describe 'MSFT_CertReq\Get-TargetResource' {
-            Mock -CommandName Get-ChildItem `
-                -Mockwith { $validCert } `
-                -ParameterFilter $pathCertLocalMachineMy_parameterFilter
+            BeforeAll {
+                Mock -CommandName Get-ChildItem `
+                    -Mockwith { $validCert } `
+                    -ParameterFilter $pathCertLocalMachineMy_parameterFilter
 
-            Mock -CommandName Get-CertificateTemplateName `
-                -MockWith { $certificateTemplate }
+                Mock -CommandName Get-CertificateTemplateName `
+                    -MockWith { $certificateTemplate }
 
-            Mock -CommandName Get-CertificateSan `
-                -MockWith { $subjectAltName }
+                Mock -CommandName Get-CertificateSan `
+                    -MockWith { $subjectAltName }
 
-            Mock -CommandName Find-CertificateAuthority -MockWith {
-                    return New-Object -TypeName psobject -Property @{
-                        CAServerFQDN = 'rootca.contoso.com'
-                        CARootName = 'contoso-CA'
+                Mock -CommandName Find-CertificateAuthority -MockWith {
+                        return New-Object -TypeName psobject -Property @{
+                            CAServerFQDN = 'rootca.contoso.com'
+                            CARootName = 'contoso-CA'
+                    }
                 }
             }
 
@@ -541,19 +543,22 @@ OID = $oid
         }
 
         Describe 'MSFT_CertReq\Set-TargetResource' {
-            BeforeEach {
-                Mock -CommandName Join-Path -MockWith { 'CertReq-Test' }
-
-                Mock -CommandName CertReq.exe
-            }
-
-            Context 'When autorenew is false, credentials not passed' {
+            BeforeAll {
                 Mock -CommandName Test-Path -MockWith { $true } `
                     -ParameterFilter $pathCertReqTestReq_parameterFilter
 
                 Mock -CommandName Test-Path -MockWith { $true } `
                     -ParameterFilter $pathCertReqTestCer_parameterFilter
 
+                Mock -CommandName Test-Path -MockWith { $true } `
+                    -ParameterFilter $pathCertReqTestOut_parameterFilter
+
+                Mock -CommandName Join-Path -MockWith { 'CertReq-Test' }
+
+                Mock -CommandName CertReq.exe
+            }
+
+            Context 'When autorenew is false, credentials not passed' {
                 Mock -CommandName Set-Content `
                     -ParameterFilter {
                         $Path -eq 'CertReq-Test.inf' -and `
@@ -585,12 +590,6 @@ OID = $oid
             }
 
             Context 'When autorenew is true, credentials not passed and certificate does not exist' {
-                Mock -CommandName Test-Path -MockWith { $true } `
-                    -ParameterFilter $pathCertReqTestReq_parameterFilter
-
-                Mock -CommandName Test-Path -MockWith { $true } `
-                    -ParameterFilter $pathCertReqTestCer_parameterFilter
-
                 Mock -CommandName Set-Content `
                     -ParameterFilter {
                         $Path -eq 'CertReq-Test.inf' -and `
@@ -627,12 +626,6 @@ OID = $oid
             }
 
             Context 'When autorenew is true, credentials not passed and valid certificate exists' {
-                Mock -CommandName Test-Path -MockWith { $true } `
-                    -ParameterFilter $pathCertReqTestReq_parameterFilter
-
-                Mock -CommandName Test-Path -MockWith { $true } `
-                    -ParameterFilter $pathCertReqTestCer_parameterFilter
-
                 Mock -CommandName Set-Content `
                     -ParameterFilter {
                         $Path -eq 'CertReq-Test.inf' -and `
@@ -669,12 +662,6 @@ OID = $oid
             }
 
             Context 'When autorenew is true, credentials not passed and expiring certificate exists' {
-                Mock -CommandName Test-Path -MockWith { $true } `
-                    -ParameterFilter $pathCertReqTestReq_parameterFilter
-
-                Mock -CommandName Test-Path -MockWith { $true } `
-                    -ParameterFilter $pathCertReqTestCer_parameterFilter
-
                 Mock -CommandName Set-Content `
                     -ParameterFilter {
                         $Path -eq 'CertReq-Test.inf' -and `
@@ -711,12 +698,6 @@ OID = $oid
             }
 
             Context 'When autorenew is true, credentials not passed and expired certificate exists' {
-                Mock -CommandName Test-Path -MockWith { $true } `
-                    -ParameterFilter $pathCertReqTestReq_parameterFilter
-
-                Mock -CommandName Test-Path -MockWith { $true } `
-                    -ParameterFilter $pathCertReqTestCer_parameterFilter
-
                 Mock -CommandName Set-Content `
                     -ParameterFilter {
                         $Path -eq 'CertReq-Test.inf' -and `
@@ -753,12 +734,6 @@ OID = $oid
             }
 
             Context 'When autorenew is true, credentials not passed, keylength passed and expired certificate exists' {
-                Mock -CommandName Test-Path -MockWith { $true } `
-                    -ParameterFilter $pathCertReqTestReq_parameterFilter
-
-                Mock -CommandName Test-Path -MockWith { $true } `
-                    -ParameterFilter $pathCertReqTestCer_parameterFilter
-
                 Mock -CommandName Set-Content `
                     -ParameterFilter {
                         $Path -eq 'CertReq-Test.inf' -and `
@@ -840,9 +815,6 @@ OID = $oid
             }
 
             Context 'When autorenew is false, credentials not passed, certificate creation failed' {
-                Mock -CommandName Test-Path -MockWith { $true } `
-                    -ParameterFilter $pathCertReqTestReq_parameterFilter
-
                 Mock -CommandName Test-Path -MockWith { $false } `
                     -ParameterFilter $pathCertReqTestCer_parameterFilter
 
@@ -884,15 +856,6 @@ OID = $oid
             }
 
             Context 'When autorenew is false, credentials passed' {
-                Mock -CommandName Test-Path -MockWith { $true } `
-                    -ParameterFilter $pathCertReqTestReq_parameterFilter
-
-                Mock -CommandName Test-Path -MockWith { $true } `
-                    -ParameterFilter $pathCertReqTestCer_parameterFilter
-
-                Mock -CommandName Test-Path -MockWith { $true } `
-                    -ParameterFilter $pathCertReqTestOut_parameterFilter
-
                 Mock -CommandName Set-Content `
                     -ParameterFilter {
                         $Path -eq 'CertReq-Test.inf'
@@ -953,12 +916,6 @@ OID = $oid
             }
 
             Context 'When autorenew is false, subject alt name passed, credentials not passed' {
-                Mock -CommandName Test-Path -MockWith { $true } `
-                    -ParameterFilter $pathCertReqTestReq_parameterFilter
-
-                Mock -CommandName Test-Path -MockWith { $true } `
-                    -ParameterFilter $pathCertReqTestCer_parameterFilter
-
                 Mock -CommandName Set-Content `
                     -ParameterFilter {
                         $Path -eq 'CertReq-Test.inf' -and `
@@ -995,12 +952,6 @@ OID = $oid
             }
 
             Context 'When standalone CA, URL for CEP and CES passed, credentials passed, inf not containing template' {
-                Mock -CommandName Test-Path -MockWith { $true } `
-                    -ParameterFilter $pathCertReqTestReq_parameterFilter
-
-                Mock -CommandName Test-Path -MockWith { $true } `
-                    -ParameterFilter $pathCertReqTestCer_parameterFilter
-
                 Mock -CommandName Set-Content -ParameterFilter {
                     $Path -eq 'CertReq-Test.inf'
                 }
@@ -1035,12 +986,6 @@ OID = $oid
             }
 
             Context 'When enterprise CA, URL for CEP and CES passed, credentials passed' {
-                Mock -CommandName Test-Path -MockWith { $true } `
-                    -ParameterFilter $pathCertReqTestReq_parameterFilter
-
-                Mock -CommandName Test-Path -MockWith { $true } `
-                    -ParameterFilter $pathCertReqTestCer_parameterFilter
-
                 Mock -CommandName Set-Content -ParameterFilter {
                     $Path -eq 'CertReq-Test.inf'
                 }
@@ -1075,15 +1020,6 @@ OID = $oid
             }
 
             Context 'When auto-discovered CA, autorenew is false, credentials passed' {
-                Mock -CommandName Test-Path -MockWith { $true } `
-                    -ParameterFilter $pathCertReqTestReq_parameterFilter
-
-                Mock -CommandName Test-Path -MockWith { $true } `
-                    -ParameterFilter $pathCertReqTestCer_parameterFilter
-
-                Mock -CommandName Test-Path -MockWith { $true } `
-                    -ParameterFilter $pathCertReqTestOut_parameterFilter
-
                 Mock -CommandName Set-Content -ParameterFilter {
                     $Path -eq 'CertReq-Test.inf'
                 }


### PR DESCRIPTION
#### Pull Request (PR) description

- CertReq:
  - Simplified unit test comparison certificate request strings to make
    tests easier to read.
  - Improved unit test layout and updated to meet standards.
  - Fixed bug in certificate renewal with `RenewalCert` attribute in the
    incorrect section - fixes [Issue 172](https://github.com/PowerShell/CertificateDsc/issues/172)
  - Fixed bug in certificate renewal when subject contains X500 path that
    is in a different order - fixes [Issue 173](https://github.com/PowerShell/CertificateDsc/issues/173)

#### This Pull Request (PR) fixes the following issues

- Fixes #172 
- Fixes #173

#### Task list

- [x] Added an entry under the Unreleased section of the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [x] Resource documentation added/updated in the resource folder.
- [x] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

@johlju - would you be able to review this one when you get a moment? I ended up cleaning up the unit tests for CertReq as they weren't up to our normal standards.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/certificatedsc/174)
<!-- Reviewable:end -->
