### PR TITLE
CertificateDSC: Adding ECDH key lengths and Request Type PKCS10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,6 @@
   - Fixed bug in certificate renewal when subject contains X500 path that
     is in a different order - fixes [Issue 173](https://github.com/PowerShell/CertificateDsc/issues/173)
 
-
 ## 4.2.0.0
 
 - Added a CODE_OF_CONDUCT.md with the same content as in the README.md - fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 - CertificateExport:
   - Fixed bug causing PFX export with matchsource enabled to fail - fixes
     [Issue 117](https://github.com/PowerShell/CertificateDsc/issues/117)
+- Added key lengths for ECDH key type.
+    - Added Key type to check for correct key lengths.
+    [Issue 113](https://github.com/PowerShell/CertificateDsc/issues/113)
+- Added request type parameter to support PKCS10.
 
 ## 4.2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
   - Fixed bug causing PFX export with matchsource enabled to fail - fixes
     [Issue 117](https://github.com/PowerShell/CertificateDsc/issues/117)
 - Added key lengths for ECDH key type.
-    - Added Key type to check for correct key lengths.
+  - Added Key type to check for correct key lengths.
     [Issue 113](https://github.com/PowerShell/CertificateDsc/issues/113)
 - Added request type parameter to support PKCS10.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,12 @@
 - CertificateExport:
   - Fixed bug causing PFX export with matchsource enabled to fail - fixes
     [Issue 117](https://github.com/PowerShell/CertificateDsc/issues/117)
-- Added key lengths for ECDH key type.
+- Added DSCResourcesToExport to the CertificateDSC.psd1
+- CertReq:
+  - Added key lengths for ECDH key type.
   - Added Key type to check for correct key lengths.
     [Issue 113](https://github.com/PowerShell/CertificateDsc/issues/113)
-- Added request type parameter to support PKCS10.
+  - Added request type parameter to support PKCS10.
 
 ## 4.2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 - Added DSCResourcesToExport to the CertificateDSC.psd1
 - CertReq:
   - Added key lengths for ECDH key type.
-  - Added Key type to check for correct key lengths.
+  - Added Key type to check for correct key lengths. - fixes
     [Issue 113](https://github.com/PowerShell/CertificateDsc/issues/113)
   - Added request type parameter to support PKCS10.
   - Simplified unit test comparison certificate request strings to make

--- a/CertificateDsc.psd1
+++ b/CertificateDsc.psd1
@@ -32,6 +32,9 @@
     # Cmdlets to export from this module
     CmdletsToExport   = '*'
 
+    # DSC resources to export from this module
+    DscResourcesToExport = @('CertificateExport','CertificateImport','CertReq','PfxImport','WaitForCertificateServices')
+
     # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
     PrivateData       = @{
 

--- a/DSCResources/MSFT_CertReq/MSFT_CertReq.psm1
+++ b/DSCResources/MSFT_CertReq/MSFT_CertReq.psm1
@@ -78,10 +78,10 @@ $localizedData = Get-LocalizedData `
     Specifies a friendly name for the certificate.
 
     .PARAMETER KeyType
-    Specifies if the key type is RSA or ECDH, defaults to RSA.
+    Specifies if the key type should be RSA or ECDH, defaults to RSA.
 
     .PARAMETER RequestType
-    Specified if the request type is CMC or PKCS10, deafults to CMC.
+    Specified if the request type should be CMC or PKCS10, deafults to CMC.
 #>
 function Get-TargetResource
 {
@@ -292,10 +292,10 @@ function Get-TargetResource
     Specifies a friendly name for the certificate.
 
     .PARAMETER KeyType
-    Specifies if the key type is RSA or ECDH, defaults to RSA.
+    Specifies if the key type should be RSA or ECDH, defaults to RSA.
 
     .PARAMETER RequestType
-    Specified if the request type is CMC or PKCS10, deafults to CMC.
+    Specified if the request type should be CMC or PKCS10, deafults to CMC.
 #>
 function Set-TargetResource
 {
@@ -741,10 +741,10 @@ CertificateTemplate = "$CertificateTemplate"
     Specifies a friendly name for the certificate.
 
     .PARAMETER KeyType
-    Specifies if the key type is RSA or ECDH, defaults to RSA.
+    Specifies if the key type should be RSA or ECDH, defaults to RSA.
 
     .PARAMETER RequestType
-    Specified if the request type is CMC or PKCS10, deafults to CMC.
+    Specified if the request type should be CMC or PKCS10, deafults to CMC.
 #>
 function Test-TargetResource
 {
@@ -997,65 +997,13 @@ function Test-TargetResource
 
 <#
     .SYNOPSIS
-
     This function will check and ensure the right key length was choosen for the key type that was intended to be used
-
-    .PARAMETER Subject
-    Provide the text string to use as the subject of the certificate.
-
-    .PARAMETER CAServerFQDN
-    The FQDN of the Active Directory Certificate Authority on the local area network.
-
-    .PARAMETER CARootName
-    The name of the certificate authority, by default this will be in format domain-servername-ca.
 
     .PARAMETER KeyLength
     The bit length of the encryption key to be used.
 
-    .PARAMETER Exportable
-    The option to allow the certificate to be exportable, by default it will be true.
-
-    .PARAMETER ProviderName
-    The selection of provider for the type of encryption to be used.
-
-    .PARAMETER OID
-    The Object Identifier that is used to name the object.
-
-    .PARAMETER KeyUsage
-    The Keyusage is a restriction method that determines what a certificate can be used for.
-
-    .PARAMETER CertificateTemplate
-    The template used for the definiton of the certificate.
-
-    .PARAMETER SubjectAltName
-    The subject alternative name used to create the certificate.
-
-    .PARAMETER Credential
-    The `PSCredential` object containing the credentials that will be used to access the template in the Certificate Authority.
-
-    .PARAMETER AutoRenew
-    Determines if the resource will also renew a certificate within 7 days of expiration.
-
-    .PARAMETER CAType
-    The type of CA in use, Standalone/Enterprise.
-
-    .PARAMETER CepURL
-    The URL to the Certification Enrollment Policy Service.
-
-    .PARAMETER CesURL
-    The URL to the Certification Enrollment Service.
-
-    .PARAMETER UseMachineContext
-    Determines if the machine should be impersonated for a request. Used for templates like Domain Controller Authentication
-
-    .PARAMETER FriendlyName
-    Specifies a friendly name for the certificate.
-
     .PARAMETER KeyType
-    Specifies if the key type is RSA or ECDH, defaults to RSA.
-
-    .PARAMETER RequestType
-    Specified if the request type is CMC or PKCS10, deafults to CMC.
+    Specifies if the key type should be RSA or ECDH, defaults to RSA.
 #>
 function Assert-ResourceProperty
 {
@@ -1073,14 +1021,15 @@ function Assert-ResourceProperty
         $KeyType = 'RSA'
     )
 
-    if ((($KeyType -eq 'RSA')  -and ($KeyLength -notin '1024', '2048', '4096', '8192')) -or `
+    if ((($KeyType -eq 'RSA') -and ($KeyLength -notin '1024', '2048', '4096', '8192')) -or `
     (($KeyType -eq 'ECDH') -and ($KeyLength -notin '192', '224', '256', '384', '521')))
     {
-        New-InvalidArgumentException -Message $($($LocalizedData.InvalidKeySize) -f $KeyLength,$KeyType) -ArgumentName 'KeyLength'
+        New-InvalidArgumentException -Message (($LocalizedData.InvalidKeySize) -f $KeyLength,$KeyType) -ArgumentName 'KeyLength'
     }
 }# end function Assert-ResourceProperty
 
 <#
+    .SYNOPSIS
     Compares two certificate subjects.
 
     .PARAMETER ReferenceSubject
@@ -1089,7 +1038,6 @@ function Assert-ResourceProperty
     .PARAMETER DifferenceSubject
     The certificate subject to compare with the ReferenceSubject.
 #>
-
 function Compare-CertificateSubject
 {
     [CmdletBinding()]

--- a/DSCResources/MSFT_CertReq/MSFT_CertReq.psm1
+++ b/DSCResources/MSFT_CertReq/MSFT_CertReq.psm1
@@ -76,6 +76,12 @@ $localizedData = Get-LocalizedData `
 
     .PARAMETER FriendlyName
     Specifies a friendly name for the certificate.
+
+    .PARAMETER KeyType
+    Specifies if the key type is RSA or ECDH, defaults to RSA.
+
+    .PARAMETER RequestType
+    Specified if the request type is CMC or PKCS10, deafults to CMC.
 #>
 function Get-TargetResource
 {
@@ -97,7 +103,7 @@ function Get-TargetResource
         $CARootName,
 
         [Parameter()]
-        [ValidateSet("1024", "2048", "4096", "8192")]
+        [ValidateSet('192', '224', '256', '384', '521', '1024', '2048', '4096', '8192')]
         [System.String]
         $KeyLength = '2048',
 
@@ -160,8 +166,20 @@ function Get-TargetResource
         [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $FriendlyName
+        $FriendlyName,
+
+        [Parameter()]
+        [ValidateSet('RSA', 'ECDH')]
+        [System.String]
+        $KeyType = 'RSA',
+
+        [Parameter()]
+        [ValidateSet('CMC', 'PKCS10')]
+        [System.String]
+        $RequestType = 'CMC'
     )
+
+    Assert-ResourceProperty @PSBoundParameters
 
     # The certificate authority, accessible on the local area network
     if ([string]::IsNullOrWhiteSpace($CAServerFQDN) -or [string]::IsNullOrWhiteSpace($CARootName))
@@ -272,6 +290,12 @@ function Get-TargetResource
 
     .PARAMETER FriendlyName
     Specifies a friendly name for the certificate.
+
+    .PARAMETER KeyType
+    Specifies if the key type is RSA or ECDH, defaults to RSA.
+
+    .PARAMETER RequestType
+    Specified if the request type is CMC or PKCS10, deafults to CMC.
 #>
 function Set-TargetResource
 {
@@ -292,7 +316,7 @@ function Set-TargetResource
         $CARootName,
 
         [Parameter()]
-        [ValidateSet("1024", "2048", "4096", "8192")]
+        [ValidateSet('192', '224', '256', '384', '521', '1024', '2048', '4096', '8192')]
         [System.String]
         $KeyLength = '2048',
 
@@ -355,8 +379,20 @@ function Set-TargetResource
         [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $FriendlyName
+        $FriendlyName,
+
+        [Parameter()]
+        [ValidateSet('RSA', 'ECDH')]
+        [System.String]
+        $KeyType = 'RSA',
+
+        [Parameter()]
+        [ValidateSet('CMC', 'PKCS10')]
+        [System.String]
+        $RequestType = 'CMC'
     )
+
+    Assert-ResourceProperty @PSBoundParameters
 
     # The certificate authority, accessible on the local area network
     if ([string]::IsNullOrWhiteSpace($CAServerFQDN) -or [string]::IsNullOrWhiteSpace($CARootName))
@@ -409,7 +445,6 @@ function Set-TargetResource
     $userProtected = 'FALSE'
     $useExistingKeySet = 'FALSE'
     $providerType = '12'
-    $requestType = 'CMC'
 
     # A unique identifier for temporary files that will be used when interacting with the command line utility
     $guid = [system.guid]::NewGuid().guid
@@ -432,7 +467,7 @@ UserProtected = $userProtected
 UseExistingKeySet = $useExistingKeySet
 ProviderName = $ProviderName
 ProviderType = $providerType
-RequestType = $requestType
+RequestType = $RequestType
 KeyUsage = $KeyUsage
 "@
     if ($FriendlyName)
@@ -472,7 +507,7 @@ CertificateTemplate = "$CertificateTemplate"
     {
         $requestDetails += @"
 
-RenewalCert = $Thumbprint
+RenewalCert = $thumbprint
 "@
     }
     Set-Content -Path $infPath -Value $requestDetails
@@ -545,8 +580,8 @@ RenewalCert = $Thumbprint
                     '-p', [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($credPW),
                     '-PolicyServer', $CepURL,
                     '-config', $CesURL,
-                    $ReqPath,
-                    $CerPath
+                    $reqPath,
+                    $cerPath
                 )
             }
             else
@@ -605,7 +640,7 @@ RenewalCert = $Thumbprint
         }
         else
         {
-            $submitRequest = & certreq.exe @('-submit', '-q', '-config', $CA, $ReqPath, $CerPath)
+            $submitRequest = & certreq.exe @('-submit', '-q', '-config', $CA, $reqPath, $cerPath)
         } # if
 
         Write-Verbose -Message ( @(
@@ -701,6 +736,12 @@ RenewalCert = $Thumbprint
 
     .PARAMETER FriendlyName
     Specifies a friendly name for the certificate.
+
+    .PARAMETER KeyType
+    Specifies if the key type is RSA or ECDH, defaults to RSA.
+
+    .PARAMETER RequestType
+    Specified if the request type is CMC or PKCS10, deafults to CMC.
 #>
 function Test-TargetResource
 {
@@ -722,7 +763,7 @@ function Test-TargetResource
         $CARootName,
 
         [Parameter()]
-        [ValidateSet("1024", "2048", "4096", "8192")]
+        [ValidateSet('192', '224', '256', '384', '521', '1024', '2048', '4096', '8192')]
         [System.String]
         $KeyLength = '2048',
 
@@ -785,8 +826,20 @@ function Test-TargetResource
         [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $FriendlyName
+        $FriendlyName,
+
+        [Parameter()]
+        [ValidateSet('RSA', 'ECDH')]
+        [System.String]
+        $KeyType = 'RSA',
+
+        [Parameter()]
+        [ValidateSet('CMC', 'PKCS10')]
+        [System.String]
+        $RequestType = 'CMC'
     )
+
+    Assert-ResourceProperty @PSBoundParameters
 
     # The certificate authority, accessible on the local area network
     if ([string]::IsNullOrWhiteSpace($CAServerFQDN) -or [string]::IsNullOrWhiteSpace($CARootName))
@@ -938,3 +991,169 @@ function Test-TargetResource
         ) -join '' )
     return $false
 } # end function Test-TargetResource
+
+<#
+    .SYNOPSIS
+    This function will check and ensure the right key length was choose for the
+
+    .PARAMETER Subject
+    Provide the text string to use as the subject of the certificate.
+
+    .PARAMETER CAServerFQDN
+    The FQDN of the Active Directory Certificate Authority on the local area network.
+
+    .PARAMETER CARootName
+    The name of the certificate authority, by default this will be in format domain-servername-ca.
+
+    .PARAMETER KeyLength
+    The bit length of the encryption key to be used.
+
+    .PARAMETER Exportable
+    The option to allow the certificate to be exportable, by default it will be true.
+
+    .PARAMETER ProviderName
+    The selection of provider for the type of encryption to be used.
+
+    .PARAMETER OID
+    The Object Identifier that is used to name the object.
+
+    .PARAMETER KeyUsage
+    The Keyusage is a restriction method that determines what a certificate can be used for.
+
+    .PARAMETER CertificateTemplate
+    The template used for the definiton of the certificate.
+
+    .PARAMETER SubjectAltName
+    The subject alternative name used to create the certificate.
+
+    .PARAMETER Credential
+    The `PSCredential` object containing the credentials that will be used to access the template in the Certificate Authority.
+
+    .PARAMETER AutoRenew
+    Determines if the resource will also renew a certificate within 7 days of expiration.
+
+    .PARAMETER CAType
+    The type of CA in use, Standalone/Enterprise.
+
+    .PARAMETER CepURL
+    The URL to the Certification Enrollment Policy Service.
+
+    .PARAMETER CesURL
+    The URL to the Certification Enrollment Service.
+
+    .PARAMETER UseMachineContext
+    Determines if the machine should be impersonated for a request. Used for templates like Domain Controller Authentication
+
+    .PARAMETER FriendlyName
+    Specifies a friendly name for the certificate.
+
+    .PARAMETER KeyType
+    Specifies if the key type is RSA or ECDH, defaults to RSA.
+
+    .PARAMETER RequestType
+    Specified if the request type is CMC or PKCS10, deafults to CMC.
+#>
+function Assert-ResourceProperty
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $Subject,
+
+        [Parameter()]
+        [System.String]
+        $CAServerFQDN,
+
+        [Parameter()]
+        [System.String]
+        $CARootName,
+
+        [Parameter()]
+        [ValidateSet('192', '224', '256', '384', '521', '1024', '2048', '4096', '8192')]
+        [System.String]
+        $KeyLength = '2048',
+
+        [Parameter()]
+        [System.Boolean]
+        $Exportable = $true,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $ProviderName = '"Microsoft RSA SChannel Cryptographic Provider"',
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $OID = '1.3.6.1.5.5.7.3.1',
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $KeyUsage = '0xa0',
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $CertificateTemplate = 'WebServer',
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $SubjectAltName,
+
+        [Parameter()]
+        [System.Management.Automation.PSCredential]
+        $Credential,
+
+        [Parameter()]
+        [System.Boolean]
+        $AutoRenew,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $CAType = 'Enterprise',
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $CepURL,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $CesURL,
+
+        [Parameter()]
+        [System.Boolean]
+        $UseMachineContext,
+
+        [Parameter()]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $FriendlyName,
+
+        [Parameter()]
+        [ValidateSet('RSA', 'ECDH')]
+        [System.String]
+        $KeyType = 'RSA',
+
+        [Parameter()]
+        [ValidateSet('CMC', 'PKCS10')]
+        [System.String]
+        $RequestType = 'CMC'
+    )
+
+    $rsaSizes = @('1024', '2048', '4096', '8192')
+    $ecdhSizes = @('192', '224', '256', '384', '521')
+
+    if ((($KeyType -eq 'RSA')  -and ($KeyLength -notin '1024', '2048', '4096', '8192')) -or `
+    (($KeyType -eq 'ECDH') -and ($KeyLength -notin '192',   '224',  '256',  '384', '521')))
+    {
+        New-InvalidArgumentException -Message $($($LocalizedData.InvalidKeySize) -f $KeyLength,$KeyType) -ArgumentName 'KeyLength'
+    }
+}# end function Assert-ResourceProperty

--- a/DSCResources/MSFT_CertReq/MSFT_CertReq.psm1
+++ b/DSCResources/MSFT_CertReq/MSFT_CertReq.psm1
@@ -1024,7 +1024,7 @@ function Assert-ResourceProperty
     if ((($KeyType -eq 'RSA') -and ($KeyLength -notin '1024', '2048', '4096', '8192')) -or `
     (($KeyType -eq 'ECDH') -and ($KeyLength -notin '192', '224', '256', '384', '521')))
     {
-        New-InvalidArgumentException -Message (($LocalizedData.InvalidKeySize) -f $KeyLength,$KeyType)
+        New-InvalidArgumentException -Message (($LocalizedData.InvalidKeySize) -f $KeyLength,$KeyType) -ArgumentName 'KeyLength'
     }
 }# end function Assert-ResourceProperty
 

--- a/DSCResources/MSFT_CertReq/MSFT_CertReq.psm1
+++ b/DSCResources/MSFT_CertReq/MSFT_CertReq.psm1
@@ -892,7 +892,7 @@ function Test-TargetResource
 
         if ($AutoRenew)
         {
-            if ($Cert.NotAfter -le (Get-Date).AddDays(-30))
+            if ($Cert.NotAfter -le (Get-Date).AddDays(30))
             {
                 # The certificate was found but it is expiring within 30 days or has expired
                 Write-Verbose -Message ( @(

--- a/DSCResources/MSFT_CertReq/MSFT_CertReq.psm1
+++ b/DSCResources/MSFT_CertReq/MSFT_CertReq.psm1
@@ -512,13 +512,6 @@ CertificateTemplate = "$CertificateTemplate"
 2.5.29.17 = "{text}$SubjectAltName"
 "@
     }
-    if ($thumbprint)
-    {
-        $requestDetails += @"
-
-RenewalCert = $thumbprint
-"@
-    }
 
     Set-Content -Path $infPath -Value $requestDetails
 

--- a/DSCResources/MSFT_CertReq/MSFT_CertReq.psm1
+++ b/DSCResources/MSFT_CertReq/MSFT_CertReq.psm1
@@ -1024,7 +1024,7 @@ function Assert-ResourceProperty
     if ((($KeyType -eq 'RSA') -and ($KeyLength -notin '1024', '2048', '4096', '8192')) -or `
     (($KeyType -eq 'ECDH') -and ($KeyLength -notin '192', '224', '256', '384', '521')))
     {
-        New-InvalidArgumentException -Message (($LocalizedData.InvalidKeySize) -f $KeyLength,$KeyType) -ArgumentName 'KeyLength'
+        New-InvalidArgumentException -Message (($LocalizedData.InvalidKeySize) -f $KeyLength,$KeyType)
     }
 }# end function Assert-ResourceProperty
 

--- a/DSCResources/MSFT_CertReq/MSFT_CertReq.psm1
+++ b/DSCResources/MSFT_CertReq/MSFT_CertReq.psm1
@@ -179,7 +179,7 @@ function Get-TargetResource
         $RequestType = 'CMC'
     )
 
-    Assert-ResourceProperty @PSBoundParameters
+    Assert-ResourceProperty -KeyLength $KeyLength -KeyType $KeyType
 
     # The certificate authority, accessible on the local area network
     if ([string]::IsNullOrWhiteSpace($CAServerFQDN) -or [string]::IsNullOrWhiteSpace($CARootName))
@@ -392,7 +392,7 @@ function Set-TargetResource
         $RequestType = 'CMC'
     )
 
-    Assert-ResourceProperty @PSBoundParameters
+    Assert-ResourceProperty -KeyLength $KeyLength -KeyType $KeyType
 
     # The certificate authority, accessible on the local area network
     if ([string]::IsNullOrWhiteSpace($CAServerFQDN) -or [string]::IsNullOrWhiteSpace($CARootName))
@@ -839,7 +839,7 @@ function Test-TargetResource
         $RequestType = 'CMC'
     )
 
-    Assert-ResourceProperty @PSBoundParameters
+    Assert-ResourceProperty -KeyLength $KeyLength -KeyType $KeyType
 
     # The certificate authority, accessible on the local area network
     if ([string]::IsNullOrWhiteSpace($CAServerFQDN) -or [string]::IsNullOrWhiteSpace($CARootName))
@@ -994,7 +994,7 @@ function Test-TargetResource
 
 <#
     .SYNOPSIS
-    This function will check and ensure the right key length was choose for the
+    This function will check and ensure the right key length was choosen for the key type that was intended to be used
 
     .PARAMETER Subject
     Provide the text string to use as the subject of the certificate.
@@ -1058,101 +1058,19 @@ function Assert-ResourceProperty
     [CmdletBinding()]
     param
     (
-        [Parameter(Mandatory = $true)]
-        [ValidateNotNullOrEmpty()]
-        [System.String]
-        $Subject,
-
-        [Parameter()]
-        [System.String]
-        $CAServerFQDN,
-
-        [Parameter()]
-        [System.String]
-        $CARootName,
-
         [Parameter()]
         [ValidateSet('192', '224', '256', '384', '521', '1024', '2048', '4096', '8192')]
         [System.String]
         $KeyLength = '2048',
 
         [Parameter()]
-        [System.Boolean]
-        $Exportable = $true,
-
-        [Parameter()]
-        [ValidateNotNullOrEmpty()]
-        [System.String]
-        $ProviderName = '"Microsoft RSA SChannel Cryptographic Provider"',
-
-        [Parameter()]
-        [ValidateNotNullOrEmpty()]
-        [System.String]
-        $OID = '1.3.6.1.5.5.7.3.1',
-
-        [Parameter()]
-        [ValidateNotNullOrEmpty()]
-        [System.String]
-        $KeyUsage = '0xa0',
-
-        [Parameter()]
-        [ValidateNotNullOrEmpty()]
-        [System.String]
-        $CertificateTemplate = 'WebServer',
-
-        [Parameter()]
-        [ValidateNotNullOrEmpty()]
-        [System.String]
-        $SubjectAltName,
-
-        [Parameter()]
-        [System.Management.Automation.PSCredential]
-        $Credential,
-
-        [Parameter()]
-        [System.Boolean]
-        $AutoRenew,
-
-        [Parameter()]
-        [ValidateNotNullOrEmpty()]
-        [System.String]
-        $CAType = 'Enterprise',
-
-        [Parameter()]
-        [ValidateNotNullOrEmpty()]
-        [System.String]
-        $CepURL,
-
-        [Parameter()]
-        [ValidateNotNullOrEmpty()]
-        [System.String]
-        $CesURL,
-
-        [Parameter()]
-        [System.Boolean]
-        $UseMachineContext,
-
-        [Parameter()]
-        [ValidateNotNullOrEmpty()]
-        [System.String]
-        $FriendlyName,
-
-        [Parameter()]
         [ValidateSet('RSA', 'ECDH')]
         [System.String]
-        $KeyType = 'RSA',
-
-        [Parameter()]
-        [ValidateSet('CMC', 'PKCS10')]
-        [System.String]
-        $RequestType = 'CMC'
+        $KeyType = 'RSA'
     )
 
-    $rsaSizes = @('1024', '2048', '4096', '8192')
-    $ecdhSizes = @('192', '224', '256', '384', '521')
-
     if ((($KeyType -eq 'RSA')  -and ($KeyLength -notin '1024', '2048', '4096', '8192')) -or `
-    (($KeyType -eq 'ECDH') -and ($KeyLength -notin '192',   '224',  '256',  '384', '521')))
+    (($KeyType -eq 'ECDH') -and ($KeyLength -notin '192', '224', '256', '384', '521')))
     {
         New-InvalidArgumentException -Message $($($LocalizedData.InvalidKeySize) -f $KeyLength,$KeyType) -ArgumentName 'KeyLength'
     }

--- a/DSCResources/MSFT_CertReq/MSFT_CertReq.schema.mof
+++ b/DSCResources/MSFT_CertReq/MSFT_CertReq.schema.mof
@@ -19,5 +19,5 @@ class MSFT_CertReq : OMI_BaseResource
     [Write, Description("Indicates whether or not the flag -adminforcemachine will be used when requesting certificates. Necessary for certain templates like e.g. DomainControllerAuthentication")] Boolean UseMachineContext;
     [Write, Description("Specifies a friendly name for the certificate.")] String FriendlyName;
     [Write, Description("Specifies key type as RSA or ECDH."), ValueMap{"RSA","ECDH"}, Values{"RSA","ECDH"}] String KeyType;
-    [Write,Description("Specifies request type as CMC or PKCS10."), ValueMap{"CMC","PKCS10"},Values{"CMC","PKCS10"}] String RequestType;
+    [Write, Description("Specifies request type as CMC or PKCS10."), ValueMap{"CMC","PKCS10"},Values{"CMC","PKCS10"}] String RequestType;
 };

--- a/DSCResources/MSFT_CertReq/MSFT_CertReq.schema.mof
+++ b/DSCResources/MSFT_CertReq/MSFT_CertReq.schema.mof
@@ -5,7 +5,7 @@ class MSFT_CertReq : OMI_BaseResource
     [Write, Description("The type of CA in use, Standalone/Enterprise.")] String CAType;
     [Write, Description("The FQDN of the Active Directory Certificate Authority on the local area network. Leave empty to automatically locate.")] String CAServerFQDN;
     [Write, Description("The name of the certificate authority, by default this will be in format domain-servername-ca. Leave empty to automatically locate.")] String CARootName;
-    [Write, Description("The bit length of the encryption key to be used. Defaults to 2048."), ValueMap{"1024","2048","4096","8192"}, Values{"1024","2048","4096","8192"}] String KeyLength;
+    [Write, Description("The bit length of the encryption key to be used. Defaults to 2048."), ValueMap{"192","224","256","384","521","1024","2048","4096","8192"}, Values{"192","224","256","384","521","1024","2048","4096","8192"}] String KeyLength;
     [Write, Description("The option to allow the certificate to be exportable, by default it will be true.")] Boolean Exportable;
     [Write, Description("The selection of provider for the type of encryption to be used.")] String ProviderName;
     [Write, Description("The Object Identifier that is used to name the object.")] String OID;
@@ -18,4 +18,6 @@ class MSFT_CertReq : OMI_BaseResource
     [Write, Description("The URL to the Certification Enrollment Service.")] String CesURL;
     [Write, Description("Indicates whether or not the flag -adminforcemachine will be used when requesting certificates. Necessary for certain templates like e.g. DomainControllerAuthentication")] Boolean UseMachineContext;
     [Write, Description("Specifies a friendly name for the certificate.")] String FriendlyName;
+    [Write, Description("Specifies key type as RSA or ECDH."), ValueMap{"RSA","ECDH"}, Values{"RSA","ECDH"}] String KeyType;
+    [Write,Description("Specifies request type as CMC or PKCS10."), ValueMap{"CMC","PKCS10"},Values{"CMC","PKCS10"}] String RequestType;
 };

--- a/DSCResources/MSFT_CertReq/MSFT_CertReq.schema.mof
+++ b/DSCResources/MSFT_CertReq/MSFT_CertReq.schema.mof
@@ -18,6 +18,6 @@ class MSFT_CertReq : OMI_BaseResource
     [Write, Description("The URL to the Certification Enrollment Service.")] String CesURL;
     [Write, Description("Indicates whether or not the flag -adminforcemachine will be used when requesting certificates. Necessary for certain templates like e.g. DomainControllerAuthentication")] Boolean UseMachineContext;
     [Write, Description("Specifies a friendly name for the certificate.")] String FriendlyName;
-    [Write, Description("Specifies key type as RSA or ECDH."), ValueMap{"RSA","ECDH"}, Values{"RSA","ECDH"}] String KeyType;
-    [Write, Description("Specifies request type as CMC or PKCS10."), ValueMap{"CMC","PKCS10"},Values{"CMC","PKCS10"}] String RequestType;
+    [Write, Description("Specifies if the key type should be RSA or ECDH, defaults to RSA."), ValueMap{"RSA","ECDH"}, Values{"RSA","ECDH"}] String KeyType;
+    [Write, Description("Specifies if the request type should be CMC or PKCS10, deafults to CMC."), ValueMap{"CMC","PKCS10"},Values{"CMC","PKCS10"}] String RequestType;
 };

--- a/DSCResources/MSFT_CertReq/en-US/MSFT_CertReq.strings.psd1
+++ b/DSCResources/MSFT_CertReq/en-US/MSFT_CertReq.strings.psd1
@@ -21,4 +21,5 @@ ConvertFrom-StringData @'
     CertReqOutNotFoundError = CertReq.exe output file '{0}' not found.
     CertTemplateMismatch = The certificate with subject '{0}' issued by '{1}' with thumbprint {2} has the wrong template {3}.
     CertFriendlyNameMismatch = The certificate with subject '{0}' issued by '{1}' with thumbprint {2} has the wrong friendly name '{3}'.
+    InvalidKeySize = The key length '{0}' specified is invalid for '{1}' key types.
 '@

--- a/Examples/Resources/CertReq/1-CertReq_RequestAltSSLCert_Config.ps1
+++ b/Examples/Resources/CertReq/1-CertReq_RequestAltSSLCert_Config.ps1
@@ -27,15 +27,14 @@
         To learn how to securely store credentials through the use of certificates,
         please refer to the following TechNet topic: https://technet.microsoft.com/en-us/library/dn781430.aspx
 #>
-configuration CertReq_RequestAltSSLCert_Config
-{
-    param
-    (
-        [Parameter(Mandatory = $true)]
-        [ValidateNotNullorEmpty()]
-        [System.Management.Automation.PSCredential]
-        $Credential
-    )
+[CmdletBinding()]
+param
+(
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullorEmpty()]
+    [System.Management.Automation.PSCredential]
+    $Credential
+)
 
     Import-DscResource -ModuleName CertificateDsc
 
@@ -56,6 +55,8 @@ configuration CertReq_RequestAltSSLCert_Config
             AutoRenew           = $true
             FriendlyName        = 'SSL Cert for Web Server'
             Credential          = $Credential
+            KeyType             = "RSA"
+            RequestType         = "CMC"
         }
     }
 }

--- a/Examples/Resources/CertReq/1-CertReq_RequestAltSSLCert_Config.ps1
+++ b/Examples/Resources/CertReq/1-CertReq_RequestAltSSLCert_Config.ps1
@@ -27,14 +27,17 @@
         To learn how to securely store credentials through the use of certificates,
         please refer to the following TechNet topic: https://technet.microsoft.com/en-us/library/dn781430.aspx
 #>
-[CmdletBinding()]
-param
-(
-    [Parameter(Mandatory = $true)]
-    [ValidateNotNullorEmpty()]
-    [System.Management.Automation.PSCredential]
-    $Credential
-)
+configuration CertReq_RequestAltSSLCert_Config
+
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullorEmpty()]
+        [System.Management.Automation.PSCredential]
+        $Credential
+    )
 
     Import-DscResource -ModuleName CertificateDsc
 
@@ -59,3 +62,4 @@ param
             RequestType         = "CMC"
         }
     }
+}

--- a/Examples/Resources/CertReq/1-CertReq_RequestAltSSLCert_Config.ps1
+++ b/Examples/Resources/CertReq/1-CertReq_RequestAltSSLCert_Config.ps1
@@ -59,4 +59,3 @@ param
             RequestType         = "CMC"
         }
     }
-}

--- a/Examples/Resources/CertReq/1-CertReq_RequestAltSSLCert_Config.ps1
+++ b/Examples/Resources/CertReq/1-CertReq_RequestAltSSLCert_Config.ps1
@@ -28,7 +28,6 @@
         please refer to the following TechNet topic: https://technet.microsoft.com/en-us/library/dn781430.aspx
 #>
 configuration CertReq_RequestAltSSLCert_Config
-
 {
     [CmdletBinding()]
     param
@@ -58,8 +57,8 @@ configuration CertReq_RequestAltSSLCert_Config
             AutoRenew           = $true
             FriendlyName        = 'SSL Cert for Web Server'
             Credential          = $Credential
-            KeyType             = "RSA"
-            RequestType         = "CMC"
+            KeyType             = 'RSA'
+            RequestType         = 'CMC'
         }
     }
 }

--- a/Examples/Resources/CertReq/2-CertReq_RequestSSLCert_Config.ps1
+++ b/Examples/Resources/CertReq/2-CertReq_RequestSSLCert_Config.ps1
@@ -37,7 +37,6 @@ configuration CertReq_RequestSSLCert_Config
         $Credential
     )
 
-
     Import-DscResource -ModuleName CertificateDsc
 
     Node localhost
@@ -56,8 +55,8 @@ configuration CertReq_RequestSSLCert_Config
             AutoRenew           = $true
             FriendlyName        = 'SSL Cert for Web Server'
             Credential          = $Credential
-            KeyType             = "RSA"
-            RequestType         = "CMC"
+            KeyType             = 'RSA'
+            RequestType         = 'CMC'
         }
     }
 }

--- a/Examples/Resources/CertReq/2-CertReq_RequestSSLCert_Config.ps1
+++ b/Examples/Resources/CertReq/2-CertReq_RequestSSLCert_Config.ps1
@@ -26,8 +26,10 @@
         To learn how to securely store credentials through the use of certificates,
         please refer to the following TechNet topic: https://technet.microsoft.com/en-us/library/dn781430.aspx
 #>
-[CmdletBinding()]
-param
+configuration CertReq_RequestSSLCert_Config
+{
+    [CmdletBinding()]
+    param
     (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullorEmpty()]
@@ -35,8 +37,7 @@ param
         $Credential
     )
 
-configuration CertReq_RequestSSLCert_Config
-{
+
     Import-DscResource -ModuleName CertificateDsc
 
     Node localhost

--- a/Examples/Resources/CertReq/2-CertReq_RequestSSLCert_Config.ps1
+++ b/Examples/Resources/CertReq/2-CertReq_RequestSSLCert_Config.ps1
@@ -26,9 +26,8 @@
         To learn how to securely store credentials through the use of certificates,
         please refer to the following TechNet topic: https://technet.microsoft.com/en-us/library/dn781430.aspx
 #>
-configuration CertReq_RequestSSLCert_Config
-{
-    param
+[CmdletBinding()]
+param
     (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullorEmpty()]
@@ -36,6 +35,8 @@ configuration CertReq_RequestSSLCert_Config
         $Credential
     )
 
+configuration CertReq_RequestSSLCert_Config
+{
     Import-DscResource -ModuleName CertificateDsc
 
     Node localhost
@@ -54,6 +55,8 @@ configuration CertReq_RequestSSLCert_Config
             AutoRenew           = $true
             FriendlyName        = 'SSL Cert for Web Server'
             Credential          = $Credential
+            KeyType             = "RSA"
+            KeyRequest          = "CMC"
         }
     }
 }

--- a/Examples/Resources/CertReq/2-CertReq_RequestSSLCert_Config.ps1
+++ b/Examples/Resources/CertReq/2-CertReq_RequestSSLCert_Config.ps1
@@ -56,7 +56,7 @@ configuration CertReq_RequestSSLCert_Config
             FriendlyName        = 'SSL Cert for Web Server'
             Credential          = $Credential
             KeyType             = "RSA"
-            KeyRequest          = "CMC"
+            RequestType         = "CMC"
         }
     }
 }

--- a/Tests/Integration/MSFT_CertReq.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_CertReq.Integration.Tests.ps1
@@ -23,7 +23,6 @@ if ([String]::IsNullOrEmpty($Result))
     return
 } # if
 
-#region HEADER
 # Integration Test Template Version: 1.1.0
 [System.String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
@@ -37,12 +36,10 @@ $TestEnvironment = Initialize-TestEnvironment `
     -DSCModuleName $script:DSCModuleName `
     -DSCResourceName $script:DSCResourceName `
     -TestType Integration
-#endregion
 
 # Using try/finally to always cleanup even if something awful happens.
 try
 {
-    #region Integration Tests
     $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
     . $ConfigFile
 
@@ -135,8 +132,7 @@ try
             }
         }
 
-        #region DEFAULT TESTS
-        Context 'WebServer certificate does not exist, Testing with RSA KeyType and CMC RequestType' {
+        Context 'When WebServer certificate does not exist, Testing with RSA KeyType and CMC RequestType' {
             It 'Should compile and apply the MOF without throwing' {
                 {
                     & "$($script:DSCResourceName)_Config" `
@@ -167,10 +163,8 @@ try
                 $CertificateNew.EnhancedKeyUsageList.ObjectId  | Should -Be $oid
             }
         }
-        #endregion
 
-        #Region Tests for New Parameters
-        Context 'WebServer certificate does not exist, Testing with ECDH KeyType and PKCS10 RequestType' {
+        Context 'When WebServer certificate does not exist, Testing with ECDH KeyType and PKCS10 RequestType' {
             It 'Should compile and apply the MOF without throwing' {
                 {
                     & "$($script:DSCResourceName)_Config" `
@@ -193,7 +187,7 @@ try
                         $_.Issuer.split(',')[0] -eq "CN=$($caRootName)"
                     }
 
-                #Removed check for key length becuase in the ECDH certificate PowerShell cannot see the length
+                # Removed check for key length becuase in the ECDH certificate PowerShell cannot see the length
                 $CertificateNew.Subject                        | Should -Be "CN=$($paramsEcdhPkcs10Request.subject)"
                 $CertificateNew.Issuer.split(',')[0]           | Should -Be "CN=$($caRootName)"
                 $CertificateNew.FriendlyName                   | Should -Be $friendlyName
@@ -227,12 +221,9 @@ try
                 -ErrorAction SilentlyContinue
         }
     }
-    #endregion
 }
 finally
 {
-    #region FOOTER
     Restore-TestEnvironment -TestEnvironment $TestEnvironment
-    #endregion
 }
 

--- a/Tests/Integration/MSFT_CertReq.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_CertReq.Integration.Tests.ps1
@@ -52,17 +52,31 @@ try
             $certUtilResult       = & "$env:SystemRoot\system32\certutil.exe" @('-dump')
             $caServerFQDN         = ([regex]::matches($certUtilResult,'Server:[ \t]+`([A-Za-z0-9._-]+)''','IgnoreCase')).Groups[1].Value
             $caRootName           = ([regex]::matches($certUtilResult,'Name:[ \t]+`([\sA-Za-z0-9._-]+)''','IgnoreCase')).Groups[1].Value
-            $keyLength            = '2048'
             $exportable           = $true
             $providerName         = '"Microsoft RSA SChannel Cryptographic Provider"'
             $oid                  = '1.3.6.1.5.5.7.3.1'
             $keyUsage             = '0xa0'
-            $certificateTemplate  = 'WebServer'
-            $subject              = "$($script:DSCResourceName)_Test"
             $dns1                 = 'contoso.com'
             $dns2                 = 'fabrikam.com'
             $subjectAltName       = "dns=$dns1&dns=$dns2"
             $friendlyName         = "$($script:DSCResourceName) Integration Test"
+
+            $paramsRsaCmcRequest = @{
+                keyLength            = '2048'
+                subject              = "$($script:DSCResourceName)_Test"
+                certificateTemplate  = 'WebServer'
+                keyType              = 'RSA'
+                RequestType          = 'CMC'
+            }
+
+            $paramsEcdhPkcs10Request = @{
+                keyLength            = '521'
+                subject              = "$($script:DSCResourceName)_Test2"
+                providerName         = '"Microsoft Software Key Storage Provider"'
+                certificateTemplate  = 'WebServer'
+                keyType              = 'ECDH'
+                RequestType          = 'PKCS10'
+            }
 
             <#
                 If automated testing with a real CA can be performed then the credentials should be
@@ -75,18 +89,45 @@ try
                 AllNodes = @(
                     @{
                         NodeName                    = 'localhost'
-                        Subject                     = $subject
+                        Subject                     = $paramsRsaCmcRequest.subject
                         CAServerFQDN                = $caServerFQDN
                         CARootName                  = $caRootName
                         Credential                  = $credential
-                        KeyLength                   = $keyLength
+                        KeyLength                   = $paramsRsaCmcRequest.keyLength
                         Exportable                  = $exportable
                         ProviderName                = $providerName
                         OID                         = $oid
                         KeyUsage                    = $keyUsage
-                        CertificateTemplate         = $certificateTemplate
+                        CertificateTemplate         = $paramsRsaCmcRequest.certificateTemplate
                         SubjectAltName              = $subjectAltName
                         FriendlyName                = $friendlyName
+                        KeyType                     = $paramsRsaCmcRequest.keyType
+                        RequestType                 = $paramsRsaCmcRequest.requestType
+                        PsDscAllowDomainUser        = $true
+                        PsDscAllowPlainTextPassword = $true
+                    }
+                )
+            }
+
+            $configDataTest2 = @{
+                AllNodes = @(
+                    @{
+                        NodeName                    = 'localhost'
+                        Subject                     = $paramsEcdhPkcs10Request.subject
+                        CAServerFQDN                = $caServerFQDN
+                        CARootName                  = $caRootName
+                        Credential                  = $credential
+                        KeyLength                   = $paramsEcdhPkcs10Request.keyLength
+                        Exportable                  = $exportable
+                        ProviderName                = $paramsEcdhPkcs10Request.providerName
+                        OID                         = $oid
+                        KeyUsage                    = $keyUsage
+                        CertificateTemplate         = $paramsEcdhPkcs10Request.certificateTemplate
+                        SubjectAltName              = $subjectAltName
+                        FriendlyName                = $friendlyName
+                        KeyType                     = $paramsEcdhPkcs10Request.keyType
+                        RequestType                 = $paramsEcdhPkcs10Request.requestType
+                        #UseMachineContext           = $true
                         PsDscAllowDomainUser        = $true
                         PsDscAllowPlainTextPassword = $true
                     }
@@ -95,7 +136,7 @@ try
         }
 
         #region DEFAULT TESTS
-        Context 'WebServer certificate does not exist' {
+        Context 'WebServer certificate does not exist, Testing with RSA KeyType and CMC RequestType' {
             It 'Should compile and apply the MOF without throwing' {
                 {
                     & "$($script:DSCResourceName)_Config" `
@@ -114,12 +155,12 @@ try
                 # Get the Certificate details
                 $CertificateNew = Get-Childitem -Path Cert:\LocalMachine\My |
                     Where-Object -FilterScript {
-                        $_.Subject -eq "CN=$($subject)" -and `
+                        $_.Subject -eq "CN=$($paramsRsaCmcRequest.subject)" -and `
                         $_.Issuer.split(',')[0] -eq "CN=$($caRootName)"
                     }
-                $CertificateNew.Subject                        | Should -Be "CN=$($subject)"
+                $CertificateNew.Subject                        | Should -Be "CN=$($paramsRsaCmcRequest.subject)"
                 $CertificateNew.Issuer.split(',')[0]           | Should -Be "CN=$($caRootName)"
-                $CertificateNew.Publickey.Key.KeySize          | Should -Be $keyLength
+                $CertificateNew.Publickey.Key.KeySize          | Should -Be $paramsRsaCmcRequest.keyLength
                 $CertificateNew.FriendlyName                   | Should -Be $friendlyName
                 $CertificateNew.DnsNameList[0]                 | Should -Be $dns1
                 $CertificateNew.DnsNameList[1]                 | Should -Be $dns2
@@ -128,16 +169,60 @@ try
         }
         #endregion
 
+        #Region Tests for New Parameters
+        Context 'WebServer certificate does not exist, Testing with ECDH KeyType and PKCS10 RequestType' {
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    & "$($script:DSCResourceName)_Config" `
+                        -OutputPath $TestDrive `
+                        -ConfigurationData $configDataTest2
+
+                    Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all the parameters should match' {
+                # Get the Certificate details
+                $CertificateNew = Get-Childitem -Path Cert:\LocalMachine\My |
+                    Where-Object -FilterScript {
+                        $_.Subject -eq "CN=$($paramsEcdhPkcs10Request.subject)" -and `
+                        $_.Issuer.split(',')[0] -eq "CN=$($caRootName)"
+                    }
+
+                #Removed check for key length becuase in the ECDH certificate PowerShell cannot see the length
+                $CertificateNew.Subject                        | Should -Be "CN=$($paramsEcdhPkcs10Request.subject)"
+                $CertificateNew.Issuer.split(',')[0]           | Should -Be "CN=$($caRootName)"
+                $CertificateNew.FriendlyName                   | Should -Be $friendlyName
+                $CertificateNew.DnsNameList[0]                 | Should -Be $dns1
+                $CertificateNew.DnsNameList[1]                 | Should -Be $dns2
+                $CertificateNew.EnhancedKeyUsageList.ObjectId  | Should -Be $oid
+            }
+        }
+
         AfterAll {
             # Cleanup
             $CertificateNew = Get-Childitem -Path Cert:\LocalMachine\My |
                 Where-Object -FilterScript {
-                    $_.Subject -eq "CN=$($subject)" -and `
+                    $_.Subject -eq "CN=$($paramsRsaCmcRequest.subject)" -and `
+                    $_.Issuer.split(',')[0] -eq "CN=$($caRootName)"
+                }
+            $CertificateNew2 = Get-Childitem -Path Cert:\LocalMachine\My |
+                Where-Object -FilterScript {
+                    $_.Subject -eq "CN=$($paramsEcdhPkcs10Request.subject)" -and `
                     $_.Issuer.split(',')[0] -eq "CN=$($caRootName)"
                 }
 
             Remove-Item `
                 -Path $CertificateNew.PSPath `
+                -Force `
+                -ErrorAction SilentlyContinue
+
+            Remove-Item `
+                -Path $CertificateNew2.PSPath `
                 -Force `
                 -ErrorAction SilentlyContinue
         }
@@ -150,3 +235,4 @@ finally
     Restore-TestEnvironment -TestEnvironment $TestEnvironment
     #endregion
 }
+

--- a/Tests/Integration/MSFT_CertReq.config.ps1
+++ b/Tests/Integration/MSFT_CertReq.config.ps1
@@ -15,6 +15,8 @@ Configuration MSFT_CertReq_Config {
             CertificateTemplate = $Node.CertificateTemplate
             SubjectAltName      = $Node.SubjectAltName
             FriendlyName        = $Node.FriendlyName
+            KeyType             = $Node.KeyType
+            RequestType         = $Node.RequestType
         }
     }
 }

--- a/Tests/Unit/MSFT_CertReq.Tests.ps1
+++ b/Tests/Unit/MSFT_CertReq.Tests.ps1
@@ -1407,14 +1407,6 @@ OID = $oid
                 }
             }
 
-            Context 'When a valid certificate already exists and DNS SANs match' {
-                Mock -CommandName Get-CertificateSan -MockWith { $subjectAltName }
-
-                It 'Should return true' {
-                    Test-TargetResource @paramsAutoRenew -Verbose | Should -Be $true
-                }
-            }
-
             Context 'When a valid certificate already exists and X500 subjects are in a different order but match' {
                 Mock -CommandName Find-CertificateAuthority -MockWith {
                     return New-Object -TypeName psobject -Property @{

--- a/Tests/Unit/MSFT_CertReq.Tests.ps1
+++ b/Tests/Unit/MSFT_CertReq.Tests.ps1
@@ -430,6 +430,26 @@ try
             KeyType               = 'ECDH'
         }
 
+        $paramRsaValid = @{
+            KeyType   = 'RSA'
+            KeyLength = '2048'
+        }
+
+        $paramRsaInvalid = @{
+            KeyType   = 'RSA'
+            KeyLength = '384'
+        }
+
+        $paramEcdhValid = @{
+            KeyType   = 'ECDH'
+            KeyLength = '384'
+        }
+
+        $paramEcdhInvalid = @{
+            KeyType   = 'ECDH'
+            KeyLength = '2048'
+        }
+
         $certInf = @"
 [NewRequest]
 Subject = "CN=$validSubject"
@@ -1405,25 +1425,25 @@ RenewalCert = $validThumbprint
         Describe "$dscResourceName\Assert-ResourceProperty"{
             Context 'When RSA key type and key length is valid' {
                 It 'Should not throw' {
-                    { Assert-ResourceProperty @paramsStandard -Verbose } | Should -Not -Throw
+                    { Assert-ResourceProperty @paramRsaValid -Verbose } | Should -Not -Throw
                 }
             }
 
             Context 'When RSA key type and key length is invalid' {
                 It 'Should not throw' {
-                    { Assert-ResourceProperty @paramsStandardInvalidRSALength -Verbose } | Should -Throw
+                    { Assert-ResourceProperty @paramRsaInvalid -Verbose } | Should -Throw
                 }
             }
 
             Context 'When ECDH key type and key length is valid' {
                 It 'Should not throw' {
-                    { Assert-ResourceProperty @paramsStandardValidECDHLength -Verbose } | Should -Not -Throw
+                    { Assert-ResourceProperty @paramEcdhValid -Verbose } | Should -Not -Throw
                 }
             }
 
             Context 'When ECDH key type and key length is invalid' {
                 It 'Should not throw' {
-                    { Assert-ResourceProperty @paramsStandardInvalidECDHLength -Verbose } | Should -Throw
+                    { Assert-ResourceProperty @paramEcdhInvalid -Verbose } | Should -Throw
                 }
             }
         }

--- a/Tests/Unit/MSFT_CertReq.Tests.ps1
+++ b/Tests/Unit/MSFT_CertReq.Tests.ps1
@@ -15,6 +15,7 @@ if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCR
 }
 
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath '\Tests\TestHelpers\CommonTestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
     -DSCModuleName $script:DSCModuleName `
     -DSCResourceName $script:DSCResourceName `
@@ -74,6 +75,7 @@ try
             NotAfter     = (Get-Date).AddDays(31) # Expires after
             FriendlyName = $invalidFriendlyName
         }
+
         Add-Member -InputObject $validCert -MemberType ScriptMethod -Name Verify -Value {
             return $true
         }
@@ -208,7 +210,7 @@ try
             FriendlyName          = $friendlyName
         }
 
-        $paramsinvalid = @{
+        $paramsInvalid = @{
             Subject               = $invalidSubject
             CAServerFQDN          = $caServerFQDN
             CARootName            = $caRootName
@@ -484,7 +486,7 @@ RenewalCert = $validThumbprint
                     }
                 }
 
-            Context 'Called without auto discovery' {
+            Context 'When called without auto discovery' {
                 $result = Get-TargetResource @paramsStandard -Verbose
 
                 It 'Should return a hashtable' {
@@ -506,7 +508,7 @@ RenewalCert = $validThumbprint
                 }
             }
 
-            Context 'Called with auto discovery' {
+            Context 'When called with auto discovery' {
                 $result = Get-TargetResource @paramsAutoDiscovery -Verbose
 
                 It 'Should return a hashtable' {
@@ -535,18 +537,18 @@ RenewalCert = $validThumbprint
             Mock Get-ChildItem -ParameterFilter { $Path -eq 'Cert:\LocalMachine\My' } `
                 -Mockwith { $invalidCert }
 
-            Context 'Called without valid cert' {
-                $results = Get-TargetResource @paramsinvalid -Verbose
+            Context 'When called without valid cert' {
+                $results = Get-TargetResource @paramsInvalid -Verbose
 
                 It 'Should return null' {
-                    $results | Should BeNullOrEmpty
+                    $results | Should -BeNullOrEmpty
                 }
             }
         }
         #endregion
 
         #region Set-TargetResource
-        Describe "$dscResourceName\Set-TargetResource" -Tag "Set" {
+        Describe "$dscResourceName\Set-TargetResource" -Tag 'Set' {
             Mock -CommandName Join-Path -MockWith { 'CertReq-Test' } `
                 -ParameterFilter { $Path -eq $env:Temp }
 
@@ -564,7 +566,7 @@ RenewalCert = $validThumbprint
                     $Value -eq $certInf
                 }
 
-            Context 'autorenew is false, credentials not passed' {
+            Context 'When autorenew is false, credentials not passed' {
                 Mock -CommandName Get-ChildItem -Mockwith { } `
                     -ParameterFilter { $Path -eq 'Cert:\LocalMachine\My' }
 
@@ -592,7 +594,7 @@ RenewalCert = $validThumbprint
             }
 
 
-            Context 'autorenew is true, credentials not passed and certificate does not exist' {
+            Context 'When autorenew is true, credentials not passed and certificate does not exist' {
                 Mock -CommandName Get-ChildItem -Mockwith { } `
                     -ParameterFilter { $Path -eq 'Cert:\LocalMachine\My' }
 
@@ -622,7 +624,7 @@ RenewalCert = $validThumbprint
                 }
             }
 
-            Context 'autorenew is true, credentials not passed and valid certificate exists' {
+            Context 'When autorenew is true, credentials not passed and valid certificate exists' {
                 Mock -CommandName Get-ChildItem -Mockwith { $validCert } `
                     -ParameterFilter { $Path -eq 'Cert:\LocalMachine\My' }
 
@@ -657,7 +659,8 @@ RenewalCert = $validThumbprint
                     $Path -eq 'CertReq-Test.inf' -and `
                     $Value -eq $certInfRenew
                 }
-            Context 'autorenew is true, credentials not passed and expiring certificate exists' {
+
+            Context 'When autorenew is true, credentials not passed and expiring certificate exists' {
                 Mock -CommandName Get-ChildItem -Mockwith { $expiringCert } `
                     -ParameterFilter { $Path -eq 'Cert:\LocalMachine\My' }
 
@@ -687,7 +690,7 @@ RenewalCert = $validThumbprint
                 }
             }
 
-            Context 'autorenew is true, credentials not passed and expired certificate exists' {
+            Context 'When autorenew is true, credentials not passed and expired certificate exists' {
                 Mock -CommandName Get-ChildItem -Mockwith { $expiredCert } `
                     -ParameterFilter { $Path -eq 'Cert:\LocalMachine\My' }
 
@@ -723,7 +726,7 @@ RenewalCert = $validThumbprint
                     $Value -eq $certInfKeyRenew
                 }
 
-            Context 'autorenew is true, credentials not passed, keylength passed and expired certificate exists' {
+            Context 'When autorenew is true, credentials not passed, keylength passed and expired certificate exists' {
                 Mock -CommandName Get-ChildItem -Mockwith { $expiredCert } `
                     -ParameterFilter { $Path -eq 'Cert:\LocalMachine\My' }
 
@@ -764,7 +767,7 @@ RenewalCert = $validThumbprint
                     $Value -eq $certInf
                 }
 
-            Context 'autorenew is false, credentials not passed, certificate request creation failed' {
+            Context 'When autorenew is false, credentials not passed, certificate request creation failed' {
                 Mock -CommandName Get-ChildItem -Mockwith { } `
                     -ParameterFilter { $Path -eq 'Cert:\LocalMachine\My' }
 
@@ -800,7 +803,7 @@ RenewalCert = $validThumbprint
             Mock -CommandName Test-Path -MockWith { $false } `
                 -ParameterFilter { $Path -eq 'CertReq-Test.cer' }
 
-            Context 'Autorenew is false, credentials not passed, certificate creation failed' {
+            Context 'When autorenew is false, credentials not passed, certificate creation failed' {
                 Mock -CommandName Get-ChildItem -Mockwith { } `
                     -ParameterFilter { $Path -eq 'Cert:\LocalMachine\My' }
 
@@ -839,7 +842,7 @@ RenewalCert = $validThumbprint
             Mock -CommandName Test-Path -MockWith { $true } `
                 -ParameterFilter { $Path -eq 'CertReq-Test.out' }
 
-            Context 'autorenew is false, credentials passed' {
+            Context 'When autorenew is false, credentials passed' {
                 Mock -CommandName Get-ChildItem -Mockwith { } `
                     -ParameterFilter { $Path -eq 'Cert:\LocalMachine\My' }
 
@@ -923,7 +926,7 @@ RenewalCert = $validThumbprint
                 }
             }
 
-            Context 'autorenew is false, credentials passed, passed ' {
+            Context 'When autorenew is false, credentials passed, passed ' {
                 Mock -CommandName Get-ChildItem -Mockwith { } `
                     -ParameterFilter { $Path -eq 'Cert:\LocalMachine\My' }
 
@@ -992,7 +995,8 @@ RenewalCert = $validThumbprint
 
                     Assert-MockCalled -CommandName CertReq.exe -Exactly 2
 
-                    Assert-MockCalled -CommandName Start-Win32Process -ModuleName MSFT_CertReq -Exactly 1 -ParameterFilter {$Arguments -like "*-adminforcemachine*"}
+                    Assert-MockCalled -CommandName Start-Win32Process -ModuleName MSFT_CertReq -Exactly 1 `
+                        -ParameterFilter {$Arguments -like "*-adminforcemachine*"}
 
                     Assert-MockCalled -CommandName Wait-Win32ProcessStop -ModuleName MSFT_CertReq -Exactly 1
 
@@ -1007,9 +1011,7 @@ RenewalCert = $validThumbprint
                 }
             }
 
-
-
-            Context 'autorenew is false, credeintals passed, no .out file' {
+            Context 'When autorenew is false, credeintals passed, no .out file' {
 
                 Mock -CommandName Test-Path -MockWith { $false } `
                 -ParameterFilter { $Path -eq 'CertReq-Test.out' }
@@ -1107,7 +1109,7 @@ RenewalCert = $validThumbprint
                     $Value -eq $certInfSubjectAltName
                 }
 
-            Context 'autorenew is false, subject alt name passed, credentials not passed' {
+            Context 'When autorenew is false, subject alt name passed, credentials not passed' {
                 Mock -CommandName Get-ChildItem -Mockwith { } `
                     -ParameterFilter { $Path -eq 'Cert:\LocalMachine\My' }
 
@@ -1134,7 +1136,7 @@ RenewalCert = $validThumbprint
                 }
             }
 
-            Context 'standalone CA, URL for CEP and CES passed, credentials passed, inf not containing template' {
+            Context 'When standalone CA, URL for CEP and CES passed, credentials passed, inf not containing template' {
                 Mock -CommandName Set-Content -ParameterFilter {
                     $Path -eq 'CertReq-Test.inf' -and `
                     $Value -eq $certInfNoTemplate
@@ -1166,7 +1168,7 @@ RenewalCert = $validThumbprint
                 }
             }
 
-            Context 'enterprise CA, URL for CEP and CES passed, credentials passed' {
+            Context 'When enterprise CA, URL for CEP and CES passed, credentials passed' {
                 Mock -CommandName Set-Content -ParameterFilter {
                     $Path -eq 'CertReq-Test.inf' -and `
                     $Value -eq $certInf
@@ -1198,7 +1200,7 @@ RenewalCert = $validThumbprint
                 }
             }
 
-            Context 'Auto-discovered CA, autorenew is false, credentials passed' {
+            Context 'When auto-discovered CA, autorenew is false, credentials passed' {
                 Mock -CommandName Get-ChildItem -Mockwith { } `
                     -ParameterFilter { $Path -eq 'Cert:\LocalMachine\My' }
 
@@ -1273,7 +1275,7 @@ RenewalCert = $validThumbprint
                 Test-TargetResource @paramsStandard -Verbose | Should -BeOfType Boolean
             }
 
-            Context 'A valid certificate does not exist' {
+            Context 'When a valid certificate does not exist' {
                 It 'Should return false' {
                     Mock Get-ChildItem -ParameterFilter { $Path -eq 'Cert:\LocalMachine\My' } `
                         -Mockwith { }
@@ -1282,7 +1284,7 @@ RenewalCert = $validThumbprint
                 }
             }
 
-            Context 'A valid certificate already exists and is not about to expire' {
+            Context 'When a valid certificate already exists and is not about to expire' {
                 It 'Should return true' {
                     Mock Get-ChildItem -ParameterFilter { $Path -eq 'Cert:\LocalMachine\My' } `
                         -Mockwith { $validCert }
@@ -1295,7 +1297,7 @@ RenewalCert = $validThumbprint
                 }
             }
 
-            Context 'An expired certificate exists and autorenew set' {
+            Context 'When an expired certificate exists and autorenew set' {
                 It 'Should return true' {
                     Mock Get-ChildItem -ParameterFilter { $Path -eq 'Cert:\LocalMachine\My' } `
                         -Mockwith { $expiredCert }
@@ -1308,7 +1310,7 @@ RenewalCert = $validThumbprint
                 }
             }
 
-            Context 'A valid certificate already exists and is about to expire and autorenew set' {
+            Context 'When a valid certificate already exists and is about to expire and autorenew set' {
                 It 'Should return false' {
                     Mock Get-ChildItem -ParameterFilter { $Path -eq 'Cert:\LocalMachine\My' } `
                         -Mockwith { $expiringCert }
@@ -1321,7 +1323,7 @@ RenewalCert = $validThumbprint
                 }
             }
 
-            Context 'A valid certificate already exists and DNS SANs match' {
+            Context 'When a valid certificate already exists and DNS SANs match' {
                 It 'Should return true' {
                     Mock Get-ChildItem -ParameterFilter { $Path -eq 'Cert:\LocalMachine\My' } `
                         -Mockwith { $validSANCert }
@@ -1332,7 +1334,7 @@ RenewalCert = $validThumbprint
                 }
             }
 
-            Context 'A certificate exists but contains incorrect DNS SANs' {
+            Context 'When a certificate exists but contains incorrect DNS SANs' {
                 It 'Should return false' {
                     Mock Get-ChildItem -ParameterFilter { $Path -eq 'Cert:\LocalMachine\My' } `
                         -Mockwith { $incorrectSANCert }
@@ -1343,7 +1345,7 @@ RenewalCert = $validThumbprint
                 }
             }
 
-            Context 'A certificate exists but does not contain specified DNS SANs' {
+            Context 'When a certificate exists but does not contain specified DNS SANs' {
                 It 'Should return false' {
                     Mock Get-ChildItem -ParameterFilter { $Path -eq 'Cert:\LocalMachine\My' } `
                         -Mockwith { $emptySANCert }
@@ -1354,7 +1356,7 @@ RenewalCert = $validThumbprint
                 }
             }
 
-            Context 'A certificate exists but does not match the Friendly Name' {
+            Context 'When a certificate exists but does not match the Friendly Name' {
                 It 'Should return false' {
                     Mock Get-ChildItem -ParameterFilter { $Path -eq 'Cert:\LocalMachine\My' } `
                         -Mockwith { $incorrectFriendlyName }
@@ -1365,7 +1367,7 @@ RenewalCert = $validThumbprint
                 }
             }
 
-            Context 'A certificate exists but does not match the Certificate Template' {
+            Context 'When a certificate exists but does not match the Certificate Template' {
                 It 'Should return false' {
                     Mock Get-ChildItem -ParameterFilter { $Path -eq 'Cert:\LocalMachine\My' } `
                         -Mockwith { $validcert }
@@ -1401,28 +1403,27 @@ RenewalCert = $validThumbprint
         }
 
         Describe "$dscResourceName\Assert-ResourceProperty"{
-
-            Context ' When RSA key type and key length is valid' {
+            Context 'When RSA key type and key length is valid' {
                 It 'Should not throw' {
-                    { Assert-ResourceProperty @paramsStandard  -Verbose } | Should -Not -Throw
+                    { Assert-ResourceProperty @paramsStandard -Verbose } | Should -Not -Throw
                 }
             }
 
-            Context ' When RSA key type and key length is invalid' {
+            Context 'When RSA key type and key length is invalid' {
                 It 'Should not throw' {
-                    { Assert-ResourceProperty @paramsStandardInvalidRSALength  -Verbose } | Should -Throw
+                    { Assert-ResourceProperty @paramsStandardInvalidRSALength -Verbose } | Should -Throw
                 }
             }
 
-            Context ' When ECDH key type and key length is valid' {
+            Context 'When ECDH key type and key length is valid' {
                 It 'Should not throw' {
-                    { Assert-ResourceProperty @paramsStandardValidECDHLength  -Verbose } | Should -Not -Throw
+                    { Assert-ResourceProperty @paramsStandardValidECDHLength -Verbose } | Should -Not -Throw
                 }
             }
 
-            Context ' When ECDH key type and key length is invalid' {
+            Context 'When ECDH key type and key length is invalid' {
                 It 'Should not throw' {
-                    { Assert-ResourceProperty @paramsStandardInvalidECDHLength  -Verbose } | Should -Throw
+                    { Assert-ResourceProperty @paramsStandardInvalidECDHLength -Verbose } | Should -Throw
                 }
             }
         }

--- a/Tests/Unit/MSFT_CertReq.Tests.ps1
+++ b/Tests/Unit/MSFT_CertReq.Tests.ps1
@@ -44,7 +44,6 @@ try
         $validIssuer                  = "CN=$caRootName, DC=contoso, DC=com"
         $invalidIssuer                = 'CN=InvalidTest, DC=invalid, DC=com'
         $keyLength                    = '2048'
-        $ecdhKeyLength                = '384'
         $exportable                   = $true
         $providerName                 = '"Microsoft RSA SChannel Cryptographic Provider"'
         $oid                          = '1.3.6.1.5.5.7.3.1'
@@ -410,54 +409,6 @@ try
             FriendlyName          = $friendlyName
         }
 
-        $paramsStandardInvalidRSALength = @{
-            Subject               = $validSubject
-            CAServerFQDN          = $caServerFQDN
-            CARootName            = $caRootName
-            KeyLength             = $ecdhKeyLength
-            Exportable            = $exportable
-            ProviderName          = $providerName
-            OID                   = $oid
-            KeyUsage              = $keyUsage
-            CertificateTemplate   = $certificateTemplate
-            Credential            = $testCredential
-            AutoRenew             = $false
-            FriendlyName          = $friendlyName
-            KeyType               = 'RSA'
-        }
-
-        $paramsStandardValidECDHLength = @{
-            Subject               = $validSubject
-            CAServerFQDN          = $caServerFQDN
-            CARootName            = $caRootName
-            KeyLength             = $ecdhKeyLength
-            Exportable            = $exportable
-            ProviderName          = $providerName
-            OID                   = $oid
-            KeyUsage              = $keyUsage
-            CertificateTemplate   = $certificateTemplate
-            Credential            = $testCredential
-            AutoRenew             = $false
-            FriendlyName          = $friendlyName
-            KeyType               = 'ECDH'
-        }
-
-        $paramsStandardInvalidECDHLength = @{
-            Subject               = $validSubject
-            CAServerFQDN          = $caServerFQDN
-            CARootName            = $caRootName
-            KeyLength             = $keyLength
-            Exportable            = $exportable
-            ProviderName          = $providerName
-            OID                   = $oid
-            KeyUsage              = $keyUsage
-            CertificateTemplate   = $certificateTemplate
-            Credential            = $testCredential
-            AutoRenew             = $false
-            FriendlyName          = $friendlyName
-            KeyType               = 'ECDH'
-        }
-
         $paramRsaValid = @{
             KeyType   = 'RSA'
             KeyLength = '2048'
@@ -617,6 +568,7 @@ OID = $oid
                 $Arguments,
 
                 [Parameter()]
+                [System.Management.Automation.PSCredential]
                 $Credential
             )
         }
@@ -632,6 +584,7 @@ OID = $oid
                 $Arguments,
 
                 [Parameter()]
+                [System.Management.Automation.PSCredential]
                 $Credential
             )
         }
@@ -1121,12 +1074,6 @@ OID = $oid
                     Assert-MockCalled -CommandName Test-Path  -Exactly 1 `
                         -ParameterFilter { $Path -eq 'CertReq-Test.cer' }
 
-                    Assert-MockCalled -CommandName Set-Content -Exactly 1 `
-                        -ParameterFilter {
-                            $Path -eq 'CertReq-Test.inf' -and `
-                            $Value -eq $certInf
-                        }
-
                     Assert-MockCalled -CommandName CertReq.exe -Exactly 2
 
                     Assert-MockCalled -CommandName Start-Win32Process -ModuleName MSFT_CertReq -Exactly 1 `
@@ -1179,12 +1126,6 @@ OID = $oid
 
                     Assert-MockCalled -CommandName Test-Path  -Exactly 1 `
                         -ParameterFilter { $Path -eq 'CertReq-Test.cer' }
-
-                    Assert-MockCalled -CommandName Set-Content -Exactly 1 `
-                        -ParameterFilter {
-                            $Path -eq 'CertReq-Test.inf' -and `
-                            $Value -eq $certInf
-                        }
 
                     Assert-MockCalled -CommandName CertReq.exe -Exactly 2
 

--- a/Tests/Unit/MSFT_CertReq.Tests.ps1
+++ b/Tests/Unit/MSFT_CertReq.Tests.ps1
@@ -1540,9 +1540,6 @@ OID = $oid
         }
 
         Describe "$dscResourceName\Assert-ResourceProperty"{
-            $errorRecord = Get-InvalidOperationRecord `
-                -Message (($LocalizedData.InvalidKeySize) -f $KeyLength,$KeyType) -ArgumentName 'KeyLength'
-
             Context 'When RSA key type and key length is valid' {
                 It 'Should not throw' {
                     { Assert-ResourceProperty @paramRsaValid -Verbose } | Should -Not -Throw

--- a/Tests/Unit/MSFT_CertReq.Tests.ps1
+++ b/Tests/Unit/MSFT_CertReq.Tests.ps1
@@ -1589,7 +1589,7 @@ OID = $oid
                     Test-TargetResource @paramsStandardDomainController -Verbose | Should -Be $true
                 }
             }
-            
+
             Context 'When auto-discover of the CA is enabled' {
                 Mock -CommandName Find-CertificateAuthority -MockWith {
                     return New-Object -TypeName psobject -Property @{
@@ -1608,7 +1608,7 @@ OID = $oid
                 }
             }
         }
-        
+
         Describe "$dscResourceName\Assert-ResourceProperty"{
             Context 'When RSA key type and key length is valid' {
                 It 'Should not throw' {
@@ -1631,6 +1631,9 @@ OID = $oid
             Context 'When ECDH key type and key length is invalid' {
                 It 'Should not throw' {
                     { Assert-ResourceProperty @paramEcdhInvalid -Verbose } | Should -Throw
+                }
+            }
+        }
 
         Describe 'MSFT_CertReq\Compare-CertificateSubject' {
             Context 'When called with matching subjects containing with single X500 paths' {

--- a/Tests/Unit/MSFT_CertReq.Tests.ps1
+++ b/Tests/Unit/MSFT_CertReq.Tests.ps1
@@ -862,7 +862,7 @@ RenewalCert = $validThumbprint
                         $Arguments,
 
                         [Parameter()]
-                        [System.Management.Automation.PSCredential]
+                        #[System.Management.Automation.PSCredential]
                         $Credential
                     )
                 }
@@ -878,7 +878,7 @@ RenewalCert = $validThumbprint
                         $Arguments,
 
                         [Parameter()]
-                        [System.Management.Automation.PSCredential]
+                        #[System.Management.Automation.PSCredential]
                         $Credential
                     )
                 }
@@ -946,7 +946,7 @@ RenewalCert = $validThumbprint
                         $Arguments,
 
                         [Parameter()]
-                        [System.Management.Automation.PSCredential]
+                        #[System.Management.Automation.PSCredential]
                         $Credential
                     )
                 }
@@ -962,7 +962,7 @@ RenewalCert = $validThumbprint
                         $Arguments,
 
                         [Parameter()]
-                        [System.Management.Automation.PSCredential]
+                        #[System.Management.Automation.PSCredential]
                         $Credential
                     )
                 }
@@ -1038,7 +1038,7 @@ RenewalCert = $validThumbprint
                         $Arguments,
 
                         [Parameter()]
-                        [System.Management.Automation.PSCredential]
+                        #[System.Management.Automation.PSCredential]
                         $Credential
                     )
                 }
@@ -1054,7 +1054,7 @@ RenewalCert = $validThumbprint
                         $Arguments,
 
                         [Parameter()]
-                        [System.Management.Automation.PSCredential]
+                        #[System.Management.Automation.PSCredential]
                         $Credential
                     )
                 }

--- a/Tests/Unit/MSFT_CertReq.Tests.ps1
+++ b/Tests/Unit/MSFT_CertReq.Tests.ps1
@@ -82,8 +82,8 @@ try
             Thumbprint   = $validThumbprint
             Subject      = "CN=$validSubject"
             Issuer       = $validIssuer
-            NotBefore    = (Get-Date).AddDays(30) # Issued on
-            NotAfter     = (Get-Date).AddDays(-30) # Expires after
+            NotBefore    = (Get-Date).AddDays(-30) # Issued on
+            NotAfter     = (Get-Date).AddDays(30) # Expires after
             FriendlyName = $friendlyName
         }
 

--- a/Tests/Unit/MSFT_CertReq.Tests.ps1
+++ b/Tests/Unit/MSFT_CertReq.Tests.ps1
@@ -1056,7 +1056,7 @@ OID = $oid
 
                 Mock -CommandName Import-Module
 
-                Mock -CommandName Start-Win32Process -ModuleName MSFT_CertReq -ParameterFilter {$Arguments -like "*-adminforcemachine*"}
+                Mock -CommandName Start-Win32Process -ModuleName MSFT_CertReq
 
                 Mock -CommandName Wait-Win32ProcessStop -ModuleName MSFT_CertReq
 

--- a/Tests/Unit/MSFT_CertReq.Tests.ps1
+++ b/Tests/Unit/MSFT_CertReq.Tests.ps1
@@ -1541,7 +1541,7 @@ OID = $oid
 
         Describe "$dscResourceName\Assert-ResourceProperty"{
             $errorRecord = Get-InvalidOperationRecord `
-                -Message (($LocalizedData.InvalidKeySize) -f $KeyLength,$KeyType) -ArgumentName 'KeyLength'
+                -Message (($LocalizedData.InvalidKeySize) -f $KeyLength,$KeyType)
 
             Context 'When RSA key type and key length is valid' {
                 It 'Should not throw' {

--- a/Tests/Unit/MSFT_CertReq.Tests.ps1
+++ b/Tests/Unit/MSFT_CertReq.Tests.ps1
@@ -1548,7 +1548,7 @@ OID = $oid
 
             Context 'When RSA key type and key length is invalid' {
                 $errorRecord = Get-InvalidOperationRecord `
-                -Message (($LocalizedData.InvalidKeySize) -f '384','RSA') -ArgumentName 'KeyLength'
+                -Message (($LocalizedData.InvalidKeySize) -f '384','RSA')
 
                 It 'Should not throw' {
                     { Assert-ResourceProperty @paramRsaInvalid -Verbose } | Should -Throw $errorRecord
@@ -1563,7 +1563,7 @@ OID = $oid
 
             Context 'When ECDH key type and key length is invalid' {
                 $errorRecord = Get-InvalidOperationRecord `
-                -Message (($LocalizedData.InvalidKeySize) -f '2048','ECDH') -ArgumentName 'KeyLength'
+                -Message (($LocalizedData.InvalidKeySize) -f '2048','ECDH')
 
                 It 'Should not throw' {
                     { Assert-ResourceProperty @paramEcdhInvalid -Verbose } | Should -Throw $errorRecord

--- a/Tests/Unit/MSFT_CertReq.Tests.ps1
+++ b/Tests/Unit/MSFT_CertReq.Tests.ps1
@@ -862,7 +862,7 @@ RenewalCert = $validThumbprint
                         $Arguments,
 
                         [Parameter()]
-                        #[System.Management.Automation.PSCredential]
+                        [System.Management.Automation.PSCredential]
                         $Credential
                     )
                 }
@@ -878,7 +878,7 @@ RenewalCert = $validThumbprint
                         $Arguments,
 
                         [Parameter()]
-                        #[System.Management.Automation.PSCredential]
+                        [System.Management.Automation.PSCredential]
                         $Credential
                     )
                 }
@@ -946,7 +946,7 @@ RenewalCert = $validThumbprint
                         $Arguments,
 
                         [Parameter()]
-                        #[System.Management.Automation.PSCredential]
+                        [System.Management.Automation.PSCredential]
                         $Credential
                     )
                 }
@@ -962,7 +962,7 @@ RenewalCert = $validThumbprint
                         $Arguments,
 
                         [Parameter()]
-                        #[System.Management.Automation.PSCredential]
+                        [System.Management.Automation.PSCredential]
                         $Credential
                     )
                 }
@@ -1038,7 +1038,7 @@ RenewalCert = $validThumbprint
                         $Arguments,
 
                         [Parameter()]
-                        #[System.Management.Automation.PSCredential]
+                        [System.Management.Automation.PSCredential]
                         $Credential
                     )
                 }
@@ -1054,7 +1054,7 @@ RenewalCert = $validThumbprint
                         $Arguments,
 
                         [Parameter()]
-                        #[System.Management.Automation.PSCredential]
+                        [System.Management.Automation.PSCredential]
                         $Credential
                     )
                 }

--- a/Tests/Unit/MSFT_CertReq.Tests.ps1
+++ b/Tests/Unit/MSFT_CertReq.Tests.ps1
@@ -1547,8 +1547,8 @@ OID = $oid
             }
 
             Context 'When RSA key type and key length is invalid' {
-                $errorRecord = Get-InvalidOperationRecord `
-                -Message (($LocalizedData.InvalidKeySize) -f '384','RSA')
+                $errorRecord = Get-InvalidArgumentRecord `
+                -Message (($LocalizedData.InvalidKeySize) -f '384','RSA') -ArgumentName 'KeyLength'
 
                 It 'Should not throw' {
                     { Assert-ResourceProperty @paramRsaInvalid -Verbose } | Should -Throw $errorRecord
@@ -1562,8 +1562,8 @@ OID = $oid
             }
 
             Context 'When ECDH key type and key length is invalid' {
-                $errorRecord = Get-InvalidOperationRecord `
-                -Message (($LocalizedData.InvalidKeySize) -f '2048','ECDH')
+                $errorRecord = Get-InvalidArgumentRecord `
+                -Message (($LocalizedData.InvalidKeySize) -f '2048','ECDH') -ArgumentName 'KeyLength'
 
                 It 'Should not throw' {
                     { Assert-ResourceProperty @paramEcdhInvalid -Verbose } | Should -Throw $errorRecord

--- a/Tests/Unit/MSFT_CertReq.Tests.ps1
+++ b/Tests/Unit/MSFT_CertReq.Tests.ps1
@@ -15,7 +15,7 @@ if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCR
 }
 
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
-Import-Module (Join-Path -Path $script:moduleRoot -ChildPath '\Tests\TestHelpers\CommonTestHelper.psm1') -Force
+
 $TestEnvironment = Initialize-TestEnvironment `
     -DSCModuleName $script:DSCModuleName `
     -DSCResourceName $script:DSCResourceName `

--- a/Tests/Unit/MSFT_CertReq.Tests.ps1
+++ b/Tests/Unit/MSFT_CertReq.Tests.ps1
@@ -1540,7 +1540,7 @@ OID = $oid
         }
 
         Describe "$dscResourceName\Assert-ResourceProperty"{
-            $errorRecord = Get-InvalidOperationsRecord `
+            $errorRecord = Get-InvalidOperationRecord `
                 -Message (($LocalizedData.InvalidKeySize) -f $KeyLength,$KeyType) -ArgumentName 'KeyLength'
 
             Context 'When RSA key type and key length is valid' {

--- a/Tests/Unit/MSFT_CertReq.Tests.ps1
+++ b/Tests/Unit/MSFT_CertReq.Tests.ps1
@@ -1541,7 +1541,7 @@ OID = $oid
 
         Describe "$dscResourceName\Assert-ResourceProperty"{
             $errorRecord = Get-InvalidOperationRecord `
-                -Message (($LocalizedData.InvalidKeySize) -f $KeyLength,$KeyType)
+                -Message (($LocalizedData.InvalidKeySize) -f $KeyLength,$KeyType) -ArgumentName 'KeyLength'
 
             Context 'When RSA key type and key length is valid' {
                 It 'Should not throw' {
@@ -1550,6 +1550,9 @@ OID = $oid
             }
 
             Context 'When RSA key type and key length is invalid' {
+                $errorRecord = Get-InvalidOperationRecord `
+                -Message (($LocalizedData.InvalidKeySize) -f '384','RSA') -ArgumentName 'KeyLength'
+
                 It 'Should not throw' {
                     { Assert-ResourceProperty @paramRsaInvalid -Verbose } | Should -Throw $errorRecord
                 }
@@ -1562,6 +1565,9 @@ OID = $oid
             }
 
             Context 'When ECDH key type and key length is invalid' {
+                $errorRecord = Get-InvalidOperationRecord `
+                -Message (($LocalizedData.InvalidKeySize) -f '2048','ECDH') -ArgumentName 'KeyLength'
+
                 It 'Should not throw' {
                     { Assert-ResourceProperty @paramEcdhInvalid -Verbose } | Should -Throw $errorRecord
                 }


### PR DESCRIPTION
#### Pull Request (PR) description
Added parameter to choose if ECDH or RSA key types are being used in an effort to ensure the right key length is chosen. Added additional key lengths to support ECDH. 

Added parameter to change the request type to PKCS10 if needed. 

#### This Pull Request (PR) fixes the following issues
    - Fixes #113 


#### Task list

- [X] Added an entry under the Unreleased section of the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in the resource folder.
- [x] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/certificatedsc/175)
<!-- Reviewable:end -->
