### PR TITLE
Fixed exception when Certificate with empty Subject exists in Certificate Store - Fixes #190

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- CertReq:
+  - Added `Compare-CertificateIssuer` function to checks if the
+    Certificate Issuer matches the CA Root Name.
+  - Changed `Compare-CertificateSubject` function to return false
+    if `ReferenceSubject` is null.
+  - Fixed error occuring when Certificate with empty Subject
+    exists in Certificate Store - fixes [Issue #190](https://github.com/PowerShell/CertificateDsc/issues/190).
+
 ## 4.5.0.0
 
 - Fix example publish to PowerShell Gallery by adding `gallery_api`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
     Certificate Issuer matches the CA Root Name.
   - Changed `Compare-CertificateSubject` function to return false
     if `ReferenceSubject` is null.
-  - Fixed error occuring when Certificate with empty Subject
-    exists in Certificate Store - fixes [Issue #190](https://github.com/PowerShell/CertificateDsc/issues/190).
+  - Fixed exception when Certificate with empty Subject exists in
+    Certificate Store - fixes [Issue #190](https://github.com/PowerShell/CertificateDsc/issues/190).
 
 ## 4.5.0.0
 

--- a/Tests/Unit/MSFT_CertReq.Tests.ps1
+++ b/Tests/Unit/MSFT_CertReq.Tests.ps1
@@ -66,6 +66,15 @@ try
             FriendlyName = $friendlyName
         }
 
+        $validCertWithoutSubject = New-Object -TypeName PSObject -Property @{
+            Thumbprint   = $validThumbprint
+            Subject      = ''
+            Issuer       = $validIssuer
+            NotBefore    = (Get-Date).AddDays(-30) # Issued on
+            NotAfter     = (Get-Date).AddDays(31) # Expires after
+            FriendlyName = $friendlyName
+        }
+
         $invalidCert = New-Object -TypeName PSObject -Property @{
             Thumbprint   = $invalidThumbprint
             Subject      = "CN=$invalidSubject"
@@ -191,6 +200,20 @@ try
         $testUsername   = 'DummyUsername'
         $testPassword   = 'DummyPassword'
         $testCredential = New-Object System.Management.Automation.PSCredential $testUsername, (ConvertTo-SecureString $testPassword -AsPlainText -Force)
+
+        $mock_getCertificateTemplateName_validCertificateTemplate = { $certificateTemplate }
+        $mock_getCertificateTemplateName_invalidCertificateTemplate = { $invalidCertificateTemplate }
+        $mock_getCertificateTemplateName_validDCCertificateTemplate = { $certificateDCTemplate }
+        $mock_GetChildItem_validCertWithoutSubject = { $validCertWithoutSubject }
+        $mock_getChildItem_validCert = { $validCert }
+        $mock_getChildItem_expiredCert = { $expiredCert }
+        $mock_getChildItem_expiringCert = { $expiringCert }
+        $mock_getChildItem_validSANCert = { $validSANCert }
+        $mock_getChildItem_validCertSubjectDifferentOrder = { $validCertSubjectDifferentOrder }
+        $mock_getChildItem_incorrectSANCert = { $incorrectSANCert }
+        $mock_getChildItem_emptySANCert = { $emptySANCert }
+        $mock_getChildItem_incorrectFriendlyName = { $incorrectFriendlyName }
+        $mock_getCertificateSan_subjectAltName = { $subjectAltName }
 
         $paramsStandard = @{
             Subject               = $validSubject
@@ -597,7 +620,7 @@ OID = $oid
                     -ParameterFilter $pathCertLocalMachineMy_parameterFilter
 
                 Mock -CommandName Get-CertificateTemplateName `
-                    -MockWith { $certificateTemplate }
+                    -MockWith $mock_getCertificateTemplateName_validCertificateTemplate
 
                 Mock -CommandName Get-CertificateSan `
                     -MockWith { $subjectAltName }
@@ -1325,15 +1348,35 @@ OID = $oid
         }
 
         Describe 'MSFT_CertReq\Test-TargetResource' {
-            Context 'When a valid certificate does not exist' {
-                Mock -CommandName Find-CertificateAuthority -MockWith {
-                    return New-Object -TypeName psobject -Property @{
-                        CARootName = "ContosoCA"
-                        CAServerFQDN = "ContosoVm.contoso.com"
+            Context 'When a valid certificate does not exist and a certificate with an empty Subject exists in the Store' {
+                Mock -CommandName Find-CertificateAuthority `
+                    -MockWith {
+                        return New-Object -TypeName psobject -Property @{
+                            CARootName = "ContosoCA"
+                            CAServerFQDN = "ContosoVm.contoso.com"
+                        }
                     }
-                }
 
-                Mock -CommandName Get-ChildItem -ParameterFilter $pathCertLocalMachineMy_parameterFilter
+                Mock -CommandName Get-ChildItem `
+                    -ParameterFilter $pathCertLocalMachineMy_parameterFilter `
+                    -Mockwith $mock_GetChildItem_validCertWithoutSubject
+
+                It 'Should return false' {
+                    Test-TargetResource @paramsStandard -Verbose | Should -Be $false
+                }
+            }
+
+            Context 'When a valid certificate does not exist' {
+                Mock -CommandName Find-CertificateAuthority `
+                    -MockWith {
+                        return New-Object -TypeName psobject -Property @{
+                            CARootName = "ContosoCA"
+                            CAServerFQDN = "ContosoVm.contoso.com"
+                        }
+                    }
+
+                Mock -CommandName Get-ChildItem `
+                    -ParameterFilter $pathCertLocalMachineMy_parameterFilter
 
                 It 'Should return false' {
                     Test-TargetResource @paramsStandard -Verbose | Should -Be $false
@@ -1341,14 +1384,17 @@ OID = $oid
             }
 
             Context 'When a valid certificate already exists' {
-                Mock -CommandName Find-CertificateAuthority -MockWith {
-                    return New-Object -TypeName psobject -Property @{
-                        CARootName = "ContosoCA"
-                        CAServerFQDN = "ContosoVm.contoso.com"
+                Mock -CommandName Find-CertificateAuthority `
+                    -MockWith {
+                        return New-Object -TypeName psobject -Property @{
+                            CARootName = "ContosoCA"
+                            CAServerFQDN = "ContosoVm.contoso.com"
+                        }
                     }
-                }
 
-                Mock -CommandName Get-ChildItem -ParameterFilter $pathCertLocalMachineMy_parameterFilter
+                Mock `
+                    -CommandName Get-ChildItem `
+                    -ParameterFilter $pathCertLocalMachineMy_parameterFilter
 
                 It 'Should return false' {
                     Test-TargetResource @paramsStandard -Verbose | Should -Be $false
@@ -1356,19 +1402,23 @@ OID = $oid
             }
 
             Context 'When a valid certificate already exists and is not about to expire' {
-                Mock -CommandName Find-CertificateAuthority -MockWith {
-                    return New-Object -TypeName psobject -Property @{
-                        CARootName = "ContosoCA"
-                        CAServerFQDN = "ContosoVm.contoso.com"
+                Mock -CommandName Find-CertificateAuthority `
+                    -MockWith {
+                        return New-Object -TypeName psobject -Property @{
+                            CARootName = "ContosoCA"
+                            CAServerFQDN = "ContosoVm.contoso.com"
+                        }
                     }
-                }
 
-                Mock -CommandName  Get-ChildItem -ParameterFilter $pathCertLocalMachineMy_parameterFilter `
-                    -Mockwith { $validCert }
+                Mock -CommandName Get-ChildItem `
+                    -ParameterFilter $pathCertLocalMachineMy_parameterFilter `
+                    -Mockwith $mock_getChildItem_validCert
 
-                Mock -CommandName Get-CertificateTemplateName -MockWith { $certificateTemplate }
+                Mock -CommandName Get-CertificateTemplateName `
+                    -MockWith $mock_getCertificateTemplateName_validCertificateTemplate
 
-                Mock -CommandName Get-CertificateSan -MockWith { $subjectAltName }
+                Mock -CommandName Get-CertificateSan `
+                    -MockWith $mock_getCertificateSan_subjectAltName
 
                 It 'Should return true' {
                     Test-TargetResource @paramsStandard -Verbose | Should -Be $true
@@ -1377,45 +1427,56 @@ OID = $oid
 
             Context 'When an expired certificate exists and autorenew set' {
                 It 'Should return true' {
-                    Mock Get-ChildItem -ParameterFilter { $Path -eq 'Cert:\LocalMachine\My' } `
-                        -Mockwith { $expiredCert }
+                    Mock -CommandName Get-ChildItem `
+                        -ParameterFilter {
+                            $Path -eq 'Cert:\LocalMachine\My'
+                        } `
+                        -Mockwith $mock_getChildItem_expiredCert
 
-                    Mock Get-CertificateTemplateName -MockWith { $certificateTemplate }
+                    Mock -CommandName Get-CertificateTemplateName `
+                        -MockWith $mock_getCertificateTemplateName_validCertificateTemplate
 
-                    Mock Get-CertificateSan -MockWith { $subjectAltName }
+                    Mock -CommandName Get-CertificateSan `
+                        -MockWith $mock_getCertificateSan_subjectAltName
 
                     Test-TargetResource @paramsStandard -Verbose | Should -Be $false
                 }
             }
 
             Context 'When a valid certificate already exists and is about to expire and autorenew set' {
-                Mock -CommandName Find-CertificateAuthority -MockWith {
-                    return New-Object -TypeName psobject -Property @{
-                        CARootName = "ContosoCA"
-                        CAServerFQDN = "ContosoVm.contoso.com"
+                Mock -CommandName Find-CertificateAuthority `
+                    -MockWith {
+                        return New-Object -TypeName psobject -Property @{
+                            CARootName = "ContosoCA"
+                            CAServerFQDN = "ContosoVm.contoso.com"
+                        }
                     }
-                }
 
-                Mock -CommandName Get-ChildItem -ParameterFilter $pathCertLocalMachineMy_parameterFilter `
-                    -Mockwith { $expiringCert }
+                Mock -CommandName Get-ChildItem `
+                    -ParameterFilter $pathCertLocalMachineMy_parameterFilter `
+                    -Mockwith $mock_getChildItem_expiringCert
 
-                Mock -CommandName Get-CertificateTemplateName -MockWith { $certificateTemplate }
+                Mock -CommandName Get-CertificateTemplateName `
+                    -MockWith $mock_getCertificateTemplateName_validCertificateTemplate
 
-                    Test-TargetResource @paramsAutoRenew -Verbose | Should -Be $false
+                Test-TargetResource @paramsAutoRenew -Verbose | Should -Be $false
             }
 
             Context 'When a valid certificate already exists and X500 subjects are in a different order but match' {
-                Mock -CommandName Find-CertificateAuthority -MockWith {
-                    return New-Object -TypeName psobject -Property @{
-                        CARootName = "ContosoCA"
-                        CAServerFQDN = "ContosoVm.contoso.com"
+                Mock -CommandName Find-CertificateAuthority `
+                    -MockWith {
+                        return New-Object -TypeName psobject -Property @{
+                            CARootName = "ContosoCA"
+                            CAServerFQDN = "ContosoVm.contoso.com"
+                        }
                     }
-                }
 
-                Mock -CommandName Get-ChildItem -ParameterFilter $pathCertLocalMachineMy_parameterFilter `
-                    -Mockwith { $validCertSubjectDifferentOrder }
+                Mock -CommandName Get-ChildItem `
+                    -ParameterFilter $pathCertLocalMachineMy_parameterFilter `
+                    -Mockwith $mock_getChildItem_validCertSubjectDifferentOrder
 
-                Mock -CommandName Get-CertificateTemplateName -MockWith { $certificateTemplate }
+                Mock -CommandName Get-CertificateTemplateName `
+                    -MockWith $mock_getCertificateTemplateName_validCertificateTemplate
 
                 It 'Should return true' {
                     Test-TargetResource @paramsSubjectDifferentOrder -Verbose | Should -Be $true
@@ -1423,17 +1484,20 @@ OID = $oid
             }
 
             Context 'When a valid certificate already exists and DNS SANs match' {
-                Mock -CommandName Find-CertificateAuthority -MockWith {
-                    return New-Object -TypeName psobject -Property @{
-                        CARootName = "ContosoCA"
-                        CAServerFQDN = "ContosoVm.contoso.com"
+                Mock -CommandName Find-CertificateAuthority `
+                    -MockWith {
+                        return New-Object -TypeName psobject -Property @{
+                            CARootName = "ContosoCA"
+                            CAServerFQDN = "ContosoVm.contoso.com"
+                        }
                     }
-                }
 
-                Mock -CommandName Get-ChildItem -ParameterFilter $pathCertLocalMachineMy_parameterFilter `
-                    -Mockwith { $validSANCert }
+                Mock -CommandName Get-ChildItem `
+                    -ParameterFilter $pathCertLocalMachineMy_parameterFilter `
+                    -Mockwith $mock_getChildItem_validSANCert
 
-                Mock -CommandName Get-CertificateTemplateName -MockWith { $certificateTemplate }
+                Mock -CommandName Get-CertificateTemplateName `
+                    -MockWith $mock_getCertificateTemplateName_validCertificateTemplate
 
                 It 'Should return true' {
                     Test-TargetResource @paramsSubjectAltName -Verbose | Should -Be $true
@@ -1441,17 +1505,20 @@ OID = $oid
             }
 
             Context 'When a certificate exists but contains incorrect DNS SANs' {
-                Mock -CommandName Find-CertificateAuthority -MockWith {
-                    return New-Object -TypeName psobject -Property @{
-                        CARootName = "ContosoCA"
-                        CAServerFQDN = "ContosoVm.contoso.com"
+                Mock -CommandName Find-CertificateAuthority `
+                    -MockWith {
+                        return New-Object -TypeName psobject -Property @{
+                            CARootName = "ContosoCA"
+                            CAServerFQDN = "ContosoVm.contoso.com"
+                        }
                     }
-                }
 
-                Mock -CommandName Get-ChildItem -ParameterFilter $pathCertLocalMachineMy_parameterFilter `
-                    -Mockwith { $incorrectSANCert }
+                Mock -CommandName Get-ChildItem `
+                    -ParameterFilter $pathCertLocalMachineMy_parameterFilter `
+                    -Mockwith $mock_getChildItem_incorrectSANCert
 
-                Mock -CommandName Get-CertificateTemplateName -MockWith { $certificateTemplate }
+                Mock -CommandName Get-CertificateTemplateName `
+                    -MockWith $mock_getCertificateTemplateName_validCertificateTemplate
 
                 It 'Should return false' {
                     Test-TargetResource @paramsSubjectAltName -Verbose | Should -Be $false
@@ -1466,10 +1533,12 @@ OID = $oid
                     }
                 }
 
-                Mock -CommandName Get-ChildItem -ParameterFilter $pathCertLocalMachineMy_parameterFilter `
-                    -Mockwith { $emptySANCert }
+                Mock -CommandName Get-ChildItem `
+                    -ParameterFilter $pathCertLocalMachineMy_parameterFilter `
+                    -Mockwith $mock_getChildItem_emptySANCert
 
-                Mock -CommandName Get-CertificateTemplateName -MockWith { $certificateTemplate }
+                Mock -CommandName Get-CertificateTemplateName `
+                    -MockWith $mock_getCertificateTemplateName_validCertificateTemplate
 
                 It 'Should return false' {
                     Test-TargetResource @paramsSubjectAltName -Verbose | Should -Be $false
@@ -1477,18 +1546,20 @@ OID = $oid
             }
 
             Context 'When a certificate exists but does not match the Friendly Name' {
-                Mock -CommandName Find-CertificateAuthority -MockWith {
-                    return New-Object -TypeName psobject -Property @{
-                        CARootName = "ContosoCA"
-                        CAServerFQDN = "ContosoVm.contoso.com"
+                Mock -CommandName Find-CertificateAuthority `
+                    -MockWith {
+                        return New-Object -TypeName psobject -Property @{
+                            CARootName = "ContosoCA"
+                            CAServerFQDN = "ContosoVm.contoso.com"
+                        }
                     }
-                }
 
-                Mock -CommandName Get-ChildItem -ParameterFilter $pathCertLocalMachineMy_parameterFilter `
-                    -Mockwith { $incorrectFriendlyName }
+                Mock -CommandName Get-ChildItem `
+                    -ParameterFilter $pathCertLocalMachineMy_parameterFilter `
+                    -Mockwith $mock_getChildItem_incorrectFriendlyName
 
-                Mock -CommandName Get-CertificateTemplateName -MockWith { $certificateTemplate }
-
+                Mock -CommandName Get-CertificateTemplateName `
+                    -MockWith $mock_getCertificateTemplateName_validCertificateTemplate
 
                 It 'Should return false' {
                     Test-TargetResource @paramsStandard -Verbose | Should -Be $false
@@ -1498,10 +1569,14 @@ OID = $oid
 
             Context 'When a certificate exists but does not match the Certificate Template' {
                 It 'Should return false' {
-                    Mock Get-ChildItem -ParameterFilter { $Path -eq 'Cert:\LocalMachine\My' } `
-                        -Mockwith { $validcert }
+                    Mock -CommandName Get-ChildItem `
+                        -ParameterFilter {
+                            $Path -eq 'Cert:\LocalMachine\My'
+                        } `
+                        -Mockwith $mock_getChildItem_validCert
 
-                    Mock Get-CertificateTemplateName -MockWith { $invalidCertificateTemplate }
+                    Mock -CommandName Get-CertificateTemplateName `
+                        -MockWith $mock_getCertificateTemplateName_invalidCertificateTemplate
 
                     Test-TargetResource @paramsStandard -Verbose | Should -Be $false
                 }
@@ -1509,26 +1584,31 @@ OID = $oid
 
             Context 'When a Domain Controller certificate template is used, A valid certificate already exists and is not about to expire' {
                 It 'Should return true' {
-                    Mock Get-ChildItem -ParameterFilter $pathCertLocalMachineMy_parameterFilter `
-                        -Mockwith { $validCert }
+                    Mock -CommandName Get-ChildItem `
+                        -ParameterFilter $pathCertLocalMachineMy_parameterFilter `
+                        -Mockwith $mock_getChildItem_validCert
 
-                    Mock Get-CertificateTemplateName -MockWith { $certificateDCTemplate }
+                    Mock -CommandName Get-CertificateTemplateName `
+                        -MockWith $mock_getCertificateTemplateName_validDCCertificateTemplate
 
-                    Mock Get-CertificateSan -MockWith { $subjectAltName }
+                    Mock -CommandName Get-CertificateSan `
+                        -MockWith $mock_getCertificateSan_subjectAltName
 
                     Test-TargetResource @paramsStandardDomainController -Verbose | Should -Be $true
                 }
             }
 
             Context 'When auto-discover of the CA is enabled' {
-                Mock -CommandName Find-CertificateAuthority -MockWith {
-                    return New-Object -TypeName psobject -Property @{
-                        CARootName = "ContosoCA"
-                        CAServerFQDN = "ContosoVm.contoso.com"
+                Mock -CommandName Find-CertificateAuthority `
+                    -MockWith {
+                        return New-Object -TypeName psobject -Property @{
+                            CARootName = "ContosoCA"
+                            CAServerFQDN = "ContosoVm.contoso.com"
+                        }
                     }
-                }
 
-                Mock -CommandName Get-ChildItem -ParameterFilter $pathCertLocalMachineMy_parameterFilter
+                Mock -CommandName Get-ChildItem `
+                    -ParameterFilter $pathCertLocalMachineMy_parameterFilter
 
                 It 'Should return false' {
                     Test-TargetResource @paramsAutoDiscovery -Verbose | Should -Be $false
@@ -1618,6 +1698,40 @@ OID = $oid
                     Compare-CertificateSubject `
                         -ReferenceSubject 'CN=xyz.contoso.com, E=xyz@contoso.com, OU=Organisation Unit, O=Organisation, L=Locality, S=State, C=country' `
                         -DifferenceSubject 'CN=xyz.contoso.com, E=xyz@contoso.com, OU=Organisation Unit, O=Organisation, L=Locality, C=country' | Should -Be $false
+                }
+            }
+        }
+
+        Describe 'MSFT_CertReq\Compare-CertificateIssuer' {
+            Context 'When called with certificate issuer with single X500 paths matching the CA root name' {
+                It 'Should return a true' {
+                    Compare-CertificateIssuer `
+                        -Issuer 'CN=xyz.contoso.com' `
+                        -CARootName 'xyz.contoso.com' | Should -Be $true
+                }
+            }
+
+            Context 'When called with certificate issuer with multiple X500 paths matching the CA root name' {
+                It 'Should return a true' {
+                    Compare-CertificateIssuer `
+                        -Issuer 'CN=xyz.contoso.com, E=xyz@contoso.com, OU=Organisation Unit, O=Organisation, L=Locality, S=State, C=country' `
+                        -CARootName 'xyz.contoso.com' | Should -Be $true
+                }
+            }
+
+            Context 'When called with certificate issuer with single X500 paths not matching the CA root name' {
+                It 'Should return a false' {
+                    Compare-CertificateIssuer `
+                        -Issuer 'CN=abc.contoso.com' `
+                        -CARootName 'xyz.contoso.com' | Should -Be $false
+                }
+            }
+
+            Context 'When called with certificate issuer with multiple X500 paths not matching the CA root name' {
+                It 'Should return a true' {
+                    Compare-CertificateIssuer `
+                        -Issuer 'CN=abc.contoso.com, E=xyz@contoso.com, OU=Organisation Unit, O=Organisation, L=Locality, S=State, C=country' `
+                        -CARootName 'xyz.contoso.com' | Should -Be $false
                 }
             }
         }

--- a/Tests/Unit/MSFT_CertReq.Tests.ps1
+++ b/Tests/Unit/MSFT_CertReq.Tests.ps1
@@ -1700,6 +1700,22 @@ OID = $oid
                         -DifferenceSubject 'CN=xyz.contoso.com, E=xyz@contoso.com, OU=Organisation Unit, O=Organisation, L=Locality, C=country' | Should -Be $false
                 }
             }
+
+            Context 'When called with a null ReferenceSubject' {
+                It 'Should return a false' {
+                    Compare-CertificateSubject `
+                        -ReferenceSubject $null `
+                        -DifferenceSubject 'CN=xyz.contoso.com, E=xyz@contoso.com, OU=Organisation Unit, O=Organisation, L=Locality, C=country' | Should -Be $false
+                }
+            }
+
+            Context 'When called with an empty ReferenceSubject' {
+                It 'Should return a false' {
+                    Compare-CertificateSubject `
+                        -ReferenceSubject '' `
+                        -DifferenceSubject 'CN=xyz.contoso.com, E=xyz@contoso.com, OU=Organisation Unit, O=Organisation, L=Locality, C=country' | Should -Be $false
+                }
+            }
         }
 
         Describe 'MSFT_CertReq\Compare-CertificateIssuer' {


### PR DESCRIPTION
#### Pull Request (PR) description

Fixed exception when Certificate with empty Subject exists in Certificate Store. I also refactored some of the unit tests and removed some code duplication by adding a new function.

#### This Pull Request (PR) fixes the following issues

- #190

#### Task list

- [x] Added an entry under the Unreleased section of the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in the resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

@johlju - would you mind reviewing this one for me when you have a moment?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/certificatedsc/191)
<!-- Reviewable:end -->
