### PR TITLE
Fix Issues with Extension Detection on non-US Localization - Fixes #193

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
     if `ReferenceSubject` is null.
   - Fixed exception when Certificate with empty Subject exists in
     Certificate Store - fixes [Issue #190](https://github.com/PowerShell/CertificateDsc/issues/190).
+  - Fixed bugs matching existing certificate when Subject Alternate
+    Name is specified and machine language is not en-US - fixes
+    [Issue #193](https://github.com/PowerShell/CertificateDsc/issues/193).
 
 ## 4.5.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,11 @@
     if `ReferenceSubject` is null.
   - Fixed exception when Certificate with empty Subject exists in
     Certificate Store - fixes [Issue #190](https://github.com/PowerShell/CertificateDsc/issues/190).
-  - Fixed bugs matching existing certificate when Subject Alternate
+  - Fixed bug matching existing certificate when Subject Alternate
     Name is specified and machine language is not en-US - fixes
+    [Issue #193](https://github.com/PowerShell/CertificateDsc/issues/193).
+  - Fixed bug matching existing certificate when Template Name
+    is specified and machine language is not en-US - fixes
     [Issue #193](https://github.com/PowerShell/CertificateDsc/issues/193).
 
 ## 4.5.0.0

--- a/DSCResources/MSFT_CertReq/MSFT_CertReq.psm1
+++ b/DSCResources/MSFT_CertReq/MSFT_CertReq.psm1
@@ -957,7 +957,6 @@ function Test-TargetResource
             else
             {
                 # There are no SANs and there should be
-                Write-Verbose -Message 'B' -Verbose
                 return $false
             }
         }

--- a/Modules/CertificateDsc.Common/CertificateDsc.Common.psm1
+++ b/Modules/CertificateDsc.Common/CertificateDsc.Common.psm1
@@ -238,7 +238,7 @@ function Find-Certificate
         $Subject,
 
         [Parameter()]
-        [String[]]
+        [System.String[]]
         $DNSName,
 
         [Parameter()]
@@ -246,11 +246,11 @@ function Find-Certificate
         $Issuer,
 
         [Parameter()]
-        [String[]]
+        [System.String[]]
         $KeyUsage,
 
         [Parameter()]
-        [String[]]
+        [System.String[]]
         $EnhancedKeyUsage,
 
         [Parameter()]

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ directly to this branch.
 
 ### dev
 
-[![Build status](https://ci.appveyor.com/api/projects/status/0u9f8smiidg1j4kn/branch/dev?svg=true)](https://ci.appveyor.com/project/PowerShell/CertificateDsc/branch/dev)[![codecov](https://codecov.io/gh/PowerShell/CertificateDsc/branch/dev/graph/badge.svg)](https://codecov.io/gh/PowerShell/CertificateDsc/branch/dev)
+[![Build status](https://ci.appveyor.com/api/projects/status/0u9f8smiidg1j4kn/branch/dev?svg=true)](https://ci.appveyor.com/project/PowerShell/CertificateDsc/branch/dev)
+[![codecov](https://codecov.io/gh/PowerShell/CertificateDsc/branch/dev/graph/badge.svg)](https://codecov.io/gh/PowerShell/CertificateDsc/branch/dev)
 
 This is the development branch to which contributions should be proposed by contributors
 as pull requests. This development branch will periodically be merged to the master

--- a/Tests/Unit/CertificateDsc.Common.Tests.ps1
+++ b/Tests/Unit/CertificateDsc.Common.Tests.ps1
@@ -1268,7 +1268,7 @@ Minor Version Number=5
         }
 
         Describe "$DSCResourceName\Get-CertificateExtension" {
-            Context 'When a certificate contains an extension that matches the Oid parameter' {
+            Context 'When a certificate contains an extension that matches the Oid parameter and First is not specified' {
                 It 'Should return the extension with Oid ''2.5.29.17''' {
                     $extension = Get-CertificateExtension -Certificate $testCertificate -Oid '2.5.29.17'
                     $extension | Should -BeOfType [System.Security.Cryptography.X509Certificates.X509Extension]
@@ -1277,7 +1277,7 @@ Minor Version Number=5
                 }
             }
 
-            Context 'When a certificate does not contain an extension that matches the Oid parameter' {
+            Context 'When a certificate does not contain an extension that matches the Oid parameter and First is not specified' {
                 It 'Should return no extension' {
                     $extension = Get-CertificateExtension -Certificate $testCertificate -Oid '2.9.9.9'
                     $extension | Should -BeNullOrEmpty
@@ -1291,7 +1291,7 @@ Minor Version Number=5
                 }
             }
 
-            Context 'When a certificate contains an extension that matches only one of the Oid parameter values' {
+            Context 'When a certificate contains an extension that matches only one of the Oid parameter values and First is not specified' {
                 It 'Should return the extension with Oid ''2.5.29.17''' {
                     $extension = Get-CertificateExtension -Certificate $testCertificate -Oid '2.5.29.17','2.9.9.9'
                     $extension | Should -BeOfType [System.Security.Cryptography.X509Certificates.X509Extension]
@@ -1300,8 +1300,8 @@ Minor Version Number=5
                 }
             }
 
-            Context 'When a certificate contains an extension that matches both of the Oid parameter values' {
-                It 'Should return the extension with Oid ''2.5.29.17'' and ''2.5.29.31''' {
+            Context 'When a certificate contains an extension that matches both of the Oid parameter values and First is not specified' {
+                It 'Should return the extension with Oid ''2.5.29.17''' {
                     $extension = Get-CertificateExtension -Certificate $testCertificate -Oid '2.5.29.17','2.5.29.31'
                     $extension | Should -BeOfType [System.Security.Cryptography.X509Certificates.X509Extension]
                     $extension | Should -HaveCount 1
@@ -1328,7 +1328,6 @@ Minor Version Number=5
                     $extension.Oid.Value | Should -Contain '2.5.29.31'
                 }
             }
-
         }
 
         Describe "$DSCResourceName\Get-CertificateTemplateExtensionText" {

--- a/Tests/Unit/CertificateDsc.Common.Tests.ps1
+++ b/Tests/Unit/CertificateDsc.Common.Tests.ps1
@@ -1387,6 +1387,26 @@ Minor Version Number=5
             }
         }
 
+        Describe "$DSCResourceName\Get-CertificateSubjectAlternativeNameList" {
+            Context 'When a certificate with a Subject Alternative Name is used' {
+                It 'Should return the list of Subject Alternative Name entries' {
+                    $global:certificate = $testCertificate
+                    $result = Get-CertificateSubjectAlternativeNameList -Certificate $testCertificate
+                    $result | Should -HaveCount 3
+                    $result | Should -Contain 'DNS Name=firstsan'
+                    $result | Should -Contain 'DNS Name=secondsan'
+                    $result | Should -Contain 'DNS Name=thirdsan'
+                }
+            }
+
+            Context 'When a certificate without Subject Alternative Name is used' {
+                It 'Should return null' {
+                    $result = Get-CertificateSubjectAlternativeNameList -Certificate $testCertificateWithoutSan
+                    $result | Should -BeNullOrEmpty
+                }
+            }
+        }
+
         Describe 'Test-CommandExists' {
             $testCommandName = 'TestCommandName'
 

--- a/Tests/Unit/CertificateDsc.Common.Tests.ps1
+++ b/Tests/Unit/CertificateDsc.Common.Tests.ps1
@@ -1129,7 +1129,6 @@ Minor Version Number=5
         }
 
         Describe "$DSCResourceName\Get-CertificateTemplateInformation" {
-
             $mockADTemplates = @(
                 @{
                     'Name'                    = 'DisplayName1'
@@ -1268,11 +1267,75 @@ Minor Version Number=5
             }
         }
 
+        Describe "$DSCResourceName\Get-CertificateExtension" {
+            Context 'When a certificate contains an extension that matches the Oid parameter' {
+                It 'Should return the extension with Oid ''2.5.29.17''' {
+                    $extension = Get-CertificateExtension -Certificate $testCertificate -Oid '2.5.29.17'
+                    $extension | Should -BeOfType [System.Security.Cryptography.X509Certificates.X509Extension]
+                    $extension | Should -HaveCount 1
+                    $extension.Oid.Value | Should -Be '2.5.29.17'
+                }
+            }
+
+            Context 'When a certificate does not contain an extension that matches the Oid parameter' {
+                It 'Should return no extension' {
+                    $extension = Get-CertificateExtension -Certificate $testCertificate -Oid '2.9.9.9'
+                    $extension | Should -BeNullOrEmpty
+                }
+            }
+
+            Context 'When a certificate does not contain an extension that matches the Oid parameter and First is set to 2' {
+                It 'Should return no extension' {
+                    $extension = Get-CertificateExtension -Certificate $testCertificate -Oid '2.9.9.9' -First 2
+                    $extension | Should -BeNullOrEmpty
+                }
+            }
+
+            Context 'When a certificate contains an extension that matches only one of the Oid parameter values' {
+                It 'Should return the extension with Oid ''2.5.29.17''' {
+                    $extension = Get-CertificateExtension -Certificate $testCertificate -Oid '2.5.29.17','2.9.9.9'
+                    $extension | Should -BeOfType [System.Security.Cryptography.X509Certificates.X509Extension]
+                    $extension | Should -HaveCount 1
+                    $extension.Oid.Value | Should -Be '2.5.29.17'
+                }
+            }
+
+            Context 'When a certificate contains an extension that matches both of the Oid parameter values' {
+                It 'Should return the extension with Oid ''2.5.29.17'' and ''2.5.29.31''' {
+                    $extension = Get-CertificateExtension -Certificate $testCertificate -Oid '2.5.29.17','2.5.29.31'
+                    $extension | Should -BeOfType [System.Security.Cryptography.X509Certificates.X509Extension]
+                    $extension | Should -HaveCount 1
+                    $extension.Oid.Value | Should -Contain '2.5.29.17'
+                }
+            }
+
+            Context 'When a certificate contains an extension that matches both of the Oid parameter values but First is set to 2' {
+                It 'Should return the extension with Oid ''2.5.29.17'' and ''2.5.29.31''' {
+                    $extension = Get-CertificateExtension -Certificate $testCertificate -Oid '2.5.29.17','2.5.29.31' -First 2
+                    $extension | Should -BeOfType [System.Security.Cryptography.X509Certificates.X509Extension]
+                    $extension | Should -HaveCount 2
+                    $extension.Oid.Value | Should -Contain '2.5.29.17'
+                    $extension.Oid.Value | Should -Contain '2.5.29.31'
+                }
+            }
+
+            Context 'When a certificate contains an extension that matches both of the Oid parameter values but First is set to 3' {
+                It 'Should return the extension with Oid ''2.5.29.17'' and ''2.5.29.31''' {
+                    $extension = Get-CertificateExtension -Certificate $testCertificate -Oid '2.5.29.17','2.5.29.31' -First 3
+                    $extension | Should -BeOfType [System.Security.Cryptography.X509Certificates.X509Extension]
+                    $extension | Should -HaveCount 2
+                    $extension.Oid.Value | Should -Contain '2.5.29.17'
+                    $extension.Oid.Value | Should -Contain '2.5.29.31'
+                }
+            }
+
+        }
+
         Describe "$DSCResourceName\Get-CertificateTemplateExtensionText" {
             Context 'When a certificate contains Certificate Template Name extension' {
                 It 'Should return the Name of the Certificate Template' {
                     $params = @{
-                        TemplateExtensions = $testCertificateWithAltTemplateName.Extensions
+                        Certificate = $testCertificateWithAltTemplateName
                     }
 
                     # Template Names have a trailing carriage return and linefeed.
@@ -1290,7 +1353,7 @@ Minor Version Number=5
 '@
 
                     $params = @{
-                        TemplateExtensions = $testCertificateWithAltTemplateInformation.Extensions
+                        Certificate = $testCertificateWithAltTemplateInformation
                     }
 
                     # Template Names have a trailing carriage return and linefeed.
@@ -1301,26 +1364,25 @@ Minor Version Number=5
             Context 'When a certificate does not contain a Certificate Template extension' {
                 It 'Should not return anything' {
                     $params = @{
-                        TemplateExtensions = $testCertificateWithoutSan.Extensions
+                        Certificate = $testCertificateWithoutSan
                     }
 
                     # Template Names have a trailing carriage return and linefeed.
                     Get-CertificateTemplateExtensionText @params | Should -Be $null
                 }
             }
-
         }
 
-        Describe "$DSCResourceName\Get-CertificateSan" {
+        Describe "$DSCResourceName\Get-CertificateSubjectAlternativeName" {
             Context 'When a certificate with a SAN is used' {
                 It 'Should return the SAN' {
-                    Get-CertificateSan -Certificate $testCertificate | Should -Be 'firstsan'
+                    Get-CertificateSubjectAlternativeName -Certificate $testCertificate | Should -Be 'firstsan'
                 }
             }
 
             Context 'When a certificate without SAN is used' {
                 It 'Should return null' {
-                    Get-CertificateSan -Certificate $testCertificateWithoutSan | Should -BeNullOrEmpty
+                    Get-CertificateSubjectAlternativeName -Certificate $testCertificateWithoutSan | Should -BeNullOrEmpty
                 }
             }
         }

--- a/Tests/Unit/MSFT_CertReq.Tests.ps1
+++ b/Tests/Unit/MSFT_CertReq.Tests.ps1
@@ -622,7 +622,7 @@ OID = $oid
                 Mock -CommandName Get-CertificateTemplateName `
                     -MockWith $mock_getCertificateTemplateName_validCertificateTemplate
 
-                Mock -CommandName Get-CertificateSan `
+                Mock -CommandName Get-CertificateSubjectAlternativeName `
                     -MockWith { $subjectAltName }
 
                 Mock -CommandName Find-CertificateAuthority -MockWith {
@@ -1417,7 +1417,7 @@ OID = $oid
                 Mock -CommandName Get-CertificateTemplateName `
                     -MockWith $mock_getCertificateTemplateName_validCertificateTemplate
 
-                Mock -CommandName Get-CertificateSan `
+                Mock -CommandName Get-CertificateSubjectAlternativeName `
                     -MockWith $mock_getCertificateSan_subjectAltName
 
                 It 'Should return true' {
@@ -1436,7 +1436,7 @@ OID = $oid
                     Mock -CommandName Get-CertificateTemplateName `
                         -MockWith $mock_getCertificateTemplateName_validCertificateTemplate
 
-                    Mock -CommandName Get-CertificateSan `
+                    Mock -CommandName Get-CertificateSubjectAlternativeName `
                         -MockWith $mock_getCertificateSan_subjectAltName
 
                     Test-TargetResource @paramsStandard -Verbose | Should -Be $false
@@ -1591,7 +1591,7 @@ OID = $oid
                     Mock -CommandName Get-CertificateTemplateName `
                         -MockWith $mock_getCertificateTemplateName_validDCCertificateTemplate
 
-                    Mock -CommandName Get-CertificateSan `
+                    Mock -CommandName Get-CertificateSubjectAlternativeName `
                         -MockWith $mock_getCertificateSan_subjectAltName
 
                     Test-TargetResource @paramsStandardDomainController -Verbose | Should -Be $true

--- a/Tests/Unit/MSFT_CertReq.Tests.ps1
+++ b/Tests/Unit/MSFT_CertReq.Tests.ps1
@@ -114,8 +114,8 @@ try
         }
 
         $sanOid = New-Object -TypeName System.Security.Cryptography.Oid -Property @{FriendlyName = 'Subject Alternative Name'}
-        $sanExt = @{
-            oid      = $(,$sanOid)
+        $sanExt = [PSCustomObject] @{
+            Oid      = $sanOid
             Critical = $false
         }
         Add-Member -InputObject $sanExt -MemberType ScriptMethod -Name Format -Force -Value {
@@ -140,15 +140,15 @@ try
             Issuer       = $validIssuer
             NotBefore    = (Get-Date).AddDays(-30) # Issued on
             NotAfter     = (Get-Date).AddDays(31) # Expires after
-            Extensions   = $sanExt
+            Extensions   = @($sanExt)
             FriendlyName = $friendlyName
         }
         Add-Member -InputObject $validSANCert -MemberType ScriptMethod -Name Verify -Value {
             return $true
         }
 
-        $incorrectSanExt = @{
-            oid      = $(,$sanOid)
+        $incorrectSanExt = [PSCustomObject] @{
+            Oid      = $sanOid
             Critical = $false
         }
         Add-Member -InputObject $incorrectSanExt -MemberType ScriptMethod -Name Format -Force -Value {
@@ -161,7 +161,7 @@ try
             Issuer       = $validIssuer
             NotBefore    = (Get-Date).AddDays(-30) # Issued on
             NotAfter     = (Get-Date).AddDays(31) # Expires after
-            Extensions   = $incorrectSanExt
+            Extensions   = @($incorrectSanExt)
             FriendlyName = $friendlyName
         }
         Add-Member -InputObject $incorrectSANCert -MemberType ScriptMethod -Name Verify -Value {
@@ -613,7 +613,7 @@ OID = $oid
             )
         }
 
-        Describe 'MSFT_CertReq\Get-TargetResource' {
+        Describe 'MSFT_CertReq\Get-TargetResource' -Tag 'Get' {
             BeforeAll {
                 Mock -CommandName Get-ChildItem `
                     -Mockwith { $validCert } `
@@ -693,9 +693,7 @@ OID = $oid
             }
         }
 
-
-        #region Set-TargetResource
-        Describe "$dscResourceName\Set-TargetResource" -Tag 'Set' {
+        Describe 'MSFT_CertReq\Set-TargetResource' -Tag 'Set' {
             BeforeAll {
                 Mock -CommandName Test-Path -MockWith { $true } `
                     -ParameterFilter $pathCertReqTestReq_parameterFilter
@@ -1347,7 +1345,7 @@ OID = $oid
             }
         }
 
-        Describe 'MSFT_CertReq\Test-TargetResource' {
+        Describe 'MSFT_CertReq\Test-TargetResource' -Tag 'Test' {
             Context 'When a valid certificate does not exist and a certificate with an empty Subject exists in the Store' {
                 Mock -CommandName Find-CertificateAuthority `
                     -MockWith {
@@ -1620,7 +1618,7 @@ OID = $oid
             }
         }
 
-        Describe "$dscResourceName\Assert-ResourceProperty"{
+        Describe 'MSFT_CertReq\Assert-ResourceProperty'{
             Context 'When RSA key type and key length is valid' {
                 It 'Should not throw' {
                     { Assert-ResourceProperty @paramRsaValid -Verbose } | Should -Not -Throw
@@ -1755,7 +1753,5 @@ OID = $oid
 }
 finally
 {
-    #region FOOTER
     Restore-TestEnvironment -TestEnvironment $testEnvironment
-    #endregion
 }


### PR DESCRIPTION
#### Pull Request (PR) description

This PR resolves issues in CertReq where extension detection fails on non-US localized machines. This is because it was using the friendly name of the extension to match. It is now converted to use the Oid values instead.

I also cleaned up style issues and reduced some code duplication and variable naming issues.

#### This Pull Request (PR) fixes the following issues

- Fixes #193 

#### Task list

- [x] Added an entry under the Unreleased section of the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in the resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

@johlju - would you mind reviewing this one for me when you get time?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/certificatedsc/196)
<!-- Reviewable:end -->
