### PR TITLE
CertificateImport: Support chained certificates (Fixes #192)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,14 @@
     if `ReferenceSubject` is null.
   - Fixed exception when Certificate with empty Subject exists in
     Certificate Store - fixes [Issue #190](https://github.com/PowerShell/CertificateDsc/issues/190).
-<<<<<<< HEAD
   - Fixed bug matching existing certificate when Subject Alternate
     Name is specified and machine language is not en-US - fixes
     [Issue #193](https://github.com/PowerShell/CertificateDsc/issues/193).
   - Fixed bug matching existing certificate when Template Name
     is specified and machine language is not en-US - fixes
     [Issue #193](https://github.com/PowerShell/CertificateDsc/issues/193).
-=======
   - Changed `Import-CertificateEx` function to use `X509Certificate2Collection`
     instead of `X509Certificate2` to support importing certificate chains
->>>>>>> Changed Import-CertificateEx function to use X509Certificate2Collection instead of X509Certificate2 to support importing certificate chains
 
 ## 4.5.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,17 @@
     if `ReferenceSubject` is null.
   - Fixed exception when Certificate with empty Subject exists in
     Certificate Store - fixes [Issue #190](https://github.com/PowerShell/CertificateDsc/issues/190).
+<<<<<<< HEAD
   - Fixed bug matching existing certificate when Subject Alternate
     Name is specified and machine language is not en-US - fixes
     [Issue #193](https://github.com/PowerShell/CertificateDsc/issues/193).
   - Fixed bug matching existing certificate when Template Name
     is specified and machine language is not en-US - fixes
     [Issue #193](https://github.com/PowerShell/CertificateDsc/issues/193).
+=======
+  - Changed `Import-CertificateEx` function to use `X509Certificate2Collection`
+    instead of `X509Certificate2` to support importing certificate chains
+>>>>>>> Changed Import-CertificateEx function to use X509Certificate2Collection instead of X509Certificate2 to support importing certificate chains
 
 ## 4.5.0.0
 

--- a/Modules/CertificateDsc.Common/CertificateDsc.Common.psm1
+++ b/Modules/CertificateDsc.Common/CertificateDsc.Common.psm1
@@ -914,7 +914,7 @@ function Import-CertificateEx
     $location = Split-Path -Path (Split-Path -Path $CertStoreLocation -Parent) -Leaf
     $store = Split-Path -Path $CertStoreLocation -Leaf
 
-    $cert = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Certificate2
+    $cert = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Certificate2Collection
     $cert.Import($FilePath)
 
     $certStore = New-Object `
@@ -922,7 +922,7 @@ function Import-CertificateEx
         -ArgumentList ($store, $location)
 
     $certStore.Open('MaxAllowed')
-    $certStore.Add($cert)
+    $certStore.AddRange($cert)
     $certStore.Close()
 }
 

--- a/Tests/Integration/CertificateDsc.Common.Tests.ps1
+++ b/Tests/Integration/CertificateDsc.Common.Tests.ps1
@@ -70,10 +70,10 @@ try
             DSC LCM runs under a different context (Local System).
         #>
         $containingCertificate = New-SelfSignedCertificate `
-            -Subject "SN=ContainingCertificate" `
+            -DnsName "ContainingCertificate" `
             -CertStoreLocation Cert:\LocalMachine\My
         $includedCertificate = New-SelfSignedCertificate `
-            -Subject "SN=IncludedCertificate" `
+            -DnsName "IncludedCertificate" `
             -CertStoreLocation Cert:\LocalMachine\My
 
         $certificatePath = Join-Path `

--- a/Tests/Integration/CertificateDsc.Common.Tests.ps1
+++ b/Tests/Integration/CertificateDsc.Common.Tests.ps1
@@ -69,6 +69,68 @@ try
             Don't use CurrentUser certificates for this test because they won't be found because
             DSC LCM runs under a different context (Local System).
         #>
+        $rootCertificate = New-SelfSignedCertificate -FriendlyName "TestRootCA" `
+            -KeyExportPolicy Exportable `
+            -Provider "Microsoft Strong Cryptographic Provider" `
+            -Subject "SN=TestRootCA" -NotAfter (Get-Date).AddYears(1) `
+            -CertStoreLocation Cert:\LocalMachine\My -KeyUsageProperty All `
+            -KeyUsage CertSign, CRLSign, DigitalSignature
+
+        $childCertificate = New-SelfSignedCertificate `
+            -Signer $rootCertificate `
+            -DnsName $ENV:ComputerName `
+            -CertStoreLocation Cert:\LocalMachine\My
+
+        $certificatePath = Join-Path `
+            -Path $ENV:Temp `
+            -ChildPath "CertificateDsc.Common.Tests-$($childCertificate.Thumbprint).p7b"
+        $certificateExportPath = Join-Path `
+            -Path $ENV:Temp `
+            -ChildPath "CertificateDsc.Common.Tests.Export-$($childCertificate.Thumbprint).p7b"
+        $testUsername = 'DummyUsername'
+        $testPassword = 'DummyPassword'
+        $testPasswordSecure = (ConvertTo-SecureString $testPassword -AsPlainText -Force)
+        $testCredential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList @($testUsername, $testPasswordSecure)
+
+        $null = @($rootCertificate, $childCertificate) | Export-Certificate `
+            -FilePath $certificatePath `
+            -Type p7b
+        $null = Remove-Item `
+            -Path $rootCertificate.PSPath `
+            -Force
+        $null = Remove-Item `
+            -Path $childCertificate.PSPath `
+            -Force
+
+        Describe "$ModuleName\Import-CertificateEx" {
+            Context 'Import a valid p7b Certificate chain into "CurrentUser\My" store' {
+                It 'Should not throw an exception' {
+                    { Import-CertificateEx -FilePath $certificatePath -CertStoreLocation 'Cert:\CurrentUser\My' } | Should -Not -Throw
+                }
+
+                It 'Should have imported the child certificate with the correct values' {
+                    $importedCert = Get-ChildItem -Path ('Cert:\CurrentUser\My\{0}' -f $childCertificate.Thumbprint)
+                    $importedCert.Thumbprint | Should -Be $childCertificate.Thumbprint
+                    $importedCert.HasPrivateKey | Should -Be $false
+                }
+
+                It 'Should have imported the root certificate with the correct values' {
+                    $importedCert = Get-ChildItem -Path ('Cert:\CurrentUser\My\{0}' -f $rootCertificate.Thumbprint)
+                    $importedCert.Thumbprint | Should -Be $rootCertificate.Thumbprint
+                    $importedCert.HasPrivateKey | Should -Be $false
+                }
+            }
+        }
+
+        # Remove the imported certificate
+        Remove-Item -Path ('Cert:\CurrentUser\My\{0}' -f $childCertificate.Thumbprint) -Force -ErrorAction SilentlyContinue
+        Remove-Item -Path ('Cert:\CurrentUser\My\{0}' -f $rootCertificate.Thumbprint) -Force -ErrorAction SilentlyContinue
+
+        <#
+            Generate a self-signed certificate, export it and remove it from the store to use for testing.
+            Don't use CurrentUser certificates for this test because they won't be found because
+            DSC LCM runs under a different context (Local System).
+        #>
         $certificate = New-SelfSignedCertificate `
             -DnsName $ENV:ComputerName `
             -CertStoreLocation Cert:\LocalMachine\My


### PR DESCRIPTION
#### Pull Request (PR) description
Adds support for importing chained certificates (ex. .p7b) back into the CertificateImport resource.  This functionality was lost in a recent change that caused all Set calls to CertificateImport to use the Import-CertificateEx function.

#### This Pull Request (PR) fixes the following issues
- Fixes #192 

#### Task list
- [x] Added an entry under the Unreleased section of the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in the resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/certificatedsc/197)
<!-- Reviewable:end -->
