### PR TITLE
CertReq: Fix Error when ProviderName not Encapsulated in Quotes - Fixes #185

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Combined all `CertificateDsc.ResourceHelper` module functions into
   `CertificateDsc.Common` module and renamed to `CertificateDsc.CommonHelper`
   module.
+- CertReq:
+  - Fix error when ProviderName parameter is not encapsulated in
+    double quotes - fixes [Issue #185](https://github.com/PowerShell/CertificateDsc/issues/185).
 
 ## 4.6.0.0
 

--- a/DSCResources/MSFT_CertReq/MSFT_CertReq.psm1
+++ b/DSCResources/MSFT_CertReq/MSFT_CertReq.psm1
@@ -430,12 +430,8 @@ function Set-TargetResource
         Information that will be used in the INF file to generate the certificate request
         In future versions, select variables from the list below could be moved to parameters!
     #>
-    $Subject = "`"$Subject`""
-    # The ProviderName must be encapsulated in double quotes
-    if ($ProviderName -notmatch '^".*"$')
-    {
-        $ProviderName = '"{0}"' -f $ProviderName
-    }
+    $Subject = ConvertTo-StringEnclosedInDoubleQuotes -Value $Subject
+    $ProviderName = ConvertTo-StringEnclosedInDoubleQuotes -Value $ProviderName
     $keySpec = '1'
     $machineKeySet = 'TRUE'
     $smime = 'FALSE'
@@ -1082,7 +1078,6 @@ function Compare-CertificateSubject
     .PARAMETER CARootName
     The CA Root Name to compare with the Certificate Issuer.
 #>
-
 function Compare-CertificateIssuer
 {
     [CmdletBinding()]
@@ -1101,4 +1096,34 @@ function Compare-CertificateIssuer
     )
 
     return ($Issuer.split(',')[0] -eq "CN=$CARootName")
+}
+
+<#
+    .SYNOPSIS
+    Ensures a string is enclosed in dobule quotes.
+
+    .PARAMETER Value
+    The string to ensure is enclosed in double quotes.
+#>
+function ConvertTo-StringEnclosedInDoubleQuotes
+{
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $Value
+    )
+
+    if ($Value[0] -ne '"')
+    {
+        $Value = '"{0}' -f $Value
+    }
+    if ($Value[$Value.Length-1] -ne '"')
+    {
+        $Value = '{0}"' -f $Value
+    }
+
+    return $Value
 }

--- a/DSCResources/MSFT_CertReq/MSFT_CertReq.psm1
+++ b/DSCResources/MSFT_CertReq/MSFT_CertReq.psm1
@@ -107,7 +107,7 @@ function Get-TargetResource
         [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $ProviderName = '"Microsoft RSA SChannel Cryptographic Provider"',
+        $ProviderName = 'Microsoft RSA SChannel Cryptographic Provider',
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
@@ -320,7 +320,7 @@ function Set-TargetResource
         [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $ProviderName = '"Microsoft RSA SChannel Cryptographic Provider"',
+        $ProviderName = 'Microsoft RSA SChannel Cryptographic Provider',
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
@@ -431,6 +431,11 @@ function Set-TargetResource
         In future versions, select variables from the list below could be moved to parameters!
     #>
     $Subject = "`"$Subject`""
+    # The ProviderName must be encapsulated in double quotes
+    if ($ProviderName[0] -ne '"')
+    {
+        $ProviderName = '"{0}"' -f $ProviderName
+    }
     $keySpec = '1'
     $machineKeySet = 'TRUE'
     $smime = 'FALSE'
@@ -770,7 +775,7 @@ function Test-TargetResource
         [Parameter()]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $ProviderName = '"Microsoft RSA SChannel Cryptographic Provider"',
+        $ProviderName = 'Microsoft RSA SChannel Cryptographic Provider',
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]

--- a/DSCResources/MSFT_CertReq/MSFT_CertReq.psm1
+++ b/DSCResources/MSFT_CertReq/MSFT_CertReq.psm1
@@ -432,7 +432,7 @@ function Set-TargetResource
     #>
     $Subject = "`"$Subject`""
     # The ProviderName must be encapsulated in double quotes
-    if ($ProviderName[0] -ne '"')
+    if ($ProviderName -notmatch '^".*"$')
     {
         $ProviderName = '"{0}"' -f $ProviderName
     }

--- a/Examples/Resources/CertReq/1-CertReq_RequestAltSSLCert_Config.ps1
+++ b/Examples/Resources/CertReq/1-CertReq_RequestAltSSLCert_Config.ps1
@@ -49,7 +49,7 @@ configuration CertReq_RequestAltSSLCert_Config
             Subject             = 'contoso.com'
             KeyLength           = '2048'
             Exportable          = $true
-            ProviderName        = '"Microsoft RSA SChannel Cryptographic Provider"'
+            ProviderName        = 'Microsoft RSA SChannel Cryptographic Provider'
             OID                 = '1.3.6.1.5.5.7.3.1'
             KeyUsage            = '0xa0'
             CertificateTemplate = 'WebServer'

--- a/Examples/Resources/CertReq/2-CertReq_RequestSSLCert_Config.ps1
+++ b/Examples/Resources/CertReq/2-CertReq_RequestSSLCert_Config.ps1
@@ -48,7 +48,7 @@ configuration CertReq_RequestSSLCert_Config
             Subject             = 'foodomain.test.net'
             KeyLength           = '2048'
             Exportable          = $true
-            ProviderName        = '"Microsoft RSA SChannel Cryptographic Provider"'
+            ProviderName        = 'Microsoft RSA SChannel Cryptographic Provider'
             OID                 = '1.3.6.1.5.5.7.3.1'
             KeyUsage            = '0xa0'
             CertificateTemplate = 'WebServer'

--- a/Tests/Integration/MSFT_CertReq.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_CertReq.Integration.Tests.ps1
@@ -50,7 +50,7 @@ try
             $caServerFQDN         = ([regex]::matches($certUtilResult,'Server:[ \t]+`([A-Za-z0-9._-]+)''','IgnoreCase')).Groups[1].Value
             $caRootName           = ([regex]::matches($certUtilResult,'Name:[ \t]+`([\sA-Za-z0-9._-]+)''','IgnoreCase')).Groups[1].Value
             $exportable           = $true
-            $providerName         = '"Microsoft RSA SChannel Cryptographic Provider"'
+            $providerName         = 'Microsoft RSA SChannel Cryptographic Provider'
             $oid                  = '1.3.6.1.5.5.7.3.1'
             $keyUsage             = '0xa0'
             $dns1                 = 'contoso.com'
@@ -69,7 +69,7 @@ try
             $paramsEcdhPkcs10Request = @{
                 keyLength            = '521'
                 subject              = "$($script:DSCResourceName)_Test2"
-                providerName         = '"Microsoft Software Key Storage Provider"'
+                providerName         = 'Microsoft Software Key Storage Provider'
                 certificateTemplate  = 'WebServer'
                 keyType              = 'ECDH'
                 RequestType          = 'PKCS10'
@@ -82,7 +82,7 @@ try
             $Credential = Get-Credential
 
             # This is to allow the testing of certreq with domain credentials
-            $configData = @{
+            $configDataRsaCmcRequest = @{
                 AllNodes = @(
                     @{
                         NodeName                    = 'localhost'
@@ -106,7 +106,7 @@ try
                 )
             }
 
-            $configDataTest2 = @{
+            $configDataRsaCmcRequestEcdhPkcs10Request = @{
                 AllNodes = @(
                     @{
                         NodeName                    = 'localhost'
@@ -124,7 +124,6 @@ try
                         FriendlyName                = $friendlyName
                         KeyType                     = $paramsEcdhPkcs10Request.keyType
                         RequestType                 = $paramsEcdhPkcs10Request.requestType
-                        #UseMachineContext           = $true
                         PsDscAllowDomainUser        = $true
                         PsDscAllowPlainTextPassword = $true
                     }
@@ -137,7 +136,7 @@ try
                 {
                     & "$($script:DSCResourceName)_Config" `
                         -OutputPath $TestDrive `
-                        -ConfigurationData $configData
+                        -ConfigurationData $configDataRsaCmcRequest
 
                     Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
                 } | Should -Not -Throw
@@ -169,7 +168,7 @@ try
                 {
                     & "$($script:DSCResourceName)_Config" `
                         -OutputPath $TestDrive `
-                        -ConfigurationData $configDataTest2
+                        -ConfigurationData $configDataRsaCmcRequestEcdhPkcs10Request
 
                     Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
                 } | Should -Not -Throw

--- a/Tests/Unit/MSFT_CertReq.Tests.ps1
+++ b/Tests/Unit/MSFT_CertReq.Tests.ps1
@@ -757,37 +757,6 @@ OID = $oid
                 }
             }
 
-                        Context 'When autorenew is false, credentials not passed' {
-                Mock -CommandName Set-Content `
-                    -ParameterFilter {
-                        $Path -eq 'CertReq-Test.inf' -and `
-                        $Value -eq $certInf
-                    }
-
-                It 'Should not throw' {
-                    { Set-TargetResource @paramsNoCred -Verbose } | Should -Not -Throw
-                }
-
-                It 'Should call expected mocks' {
-                    Assert-MockCalled -CommandName Join-Path -Exactly -Times 1 `
-                        -ParameterFilter $pathTemp_parameterFilter
-
-                    Assert-MockCalled -CommandName Test-Path -Exactly -Times 1 `
-                        -ParameterFilter $pathCertReqTestReq_parameterFilter
-
-                    Assert-MockCalled -CommandName Test-Path  -Exactly -Times 1 `
-                        -ParameterFilter $pathCertReqTestCer_parameterFilter
-
-                    Assert-MockCalled -CommandName CertReq.exe -Exactly -Times 3
-
-                    Assert-MockCalled -CommandName Set-Content -Exactly -Times 1 `
-                        -ParameterFilter {
-                            $Path -eq 'CertReq-Test.inf' -and `
-                            $Value -eq $certInf
-                        }
-                }
-            }
-
             Context 'When autorenew is true, credentials not passed and certificate does not exist' {
                 Mock -CommandName Set-Content `
                     -ParameterFilter {

--- a/Tests/Unit/MSFT_CertReq.Tests.ps1
+++ b/Tests/Unit/MSFT_CertReq.Tests.ps1
@@ -1826,6 +1826,28 @@ OID = $oid
                 }
             }
         }
+
+        Describe 'MSFT_CertReq\ConvertTo-StringEnclosedInDoubleQuotes' {
+            Context 'When called with test values' {
+                $testValues = @(
+                    @{ Value = 'test' },
+                    @{ Value = '"test' },
+                    @{ Value = 'test"' },
+                    @{ Value = '"test"' }
+                )
+
+                It 'Should return ''"test"'' when called with ''<Value>''' -TestCases $testValues {
+                    param
+                    (
+                        [Parameter()]
+                        [System.String]
+                        $Value
+                    )
+
+                    ConvertTo-StringEnclosedInDoubleQuotes -Value $Value | Should -Be '"test"'
+                }
+            }
+        }
     }
 }
 finally


### PR DESCRIPTION
#### Pull Request (PR) description

This PR changes CertReq so that it doesn't require the ProviderName to be encapsulated in double quotes. It will still work correctly even if it is encapsulated.

#### This Pull Request (PR) fixes the following issues

- Fixes #185

#### Task list

- [x] Added an entry under the Unreleased section of the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in the resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

@johlju - would you mind reviewing this one when you get a moment?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/certificatedsc/201)
<!-- Reviewable:end -->
