### PR TITLE
CertReq: Removed hardcoded references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,10 @@
 - CertReq:
   - Fix error when ProviderName parameter is not encapsulated in
     double quotes - fixes [Issue #185](https://github.com/PowerShell/CertificateDsc/issues/185).
-  - Fix for multiple certificates being issued when having a third party CA which
-    doesn't format the Issuer CN in the same order as a MS CA - fixes
-    [Issue #207](https://github.com/PowerShell/CertificateDsc/issues/207).
+  - Added `Get-CertificateCommonName` function as a fix for multiple certificates
+    being issued when having a third party CA which doesn't format the Issuer CN
+    in the same order as a MS CA - fixes [Issue #207](https://github.com/PowerShell/CertificateDsc/issues/207).
+  - Updated `Compare-CertificateIssuer` to use the new `Get-CertificateCommonName` function.
 - Refactor integration tests to update to latest standards.
 - Refactor unit tests to update to latest standards.
 - CertificateImport:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,13 @@
 - CertReq:
   - Fix error when ProviderName parameter is not encapsulated in
     double quotes - fixes [Issue #185](https://github.com/PowerShell/CertificateDsc/issues/185).
-  - Added `Get-CertificateCommonName` function as a fix for multiple certificates
-    being issued when having a third party CA which doesn't format the Issuer CN
-    in the same order as a MS CA - fixes [Issue #207](https://github.com/PowerShell/CertificateDsc/issues/207).
-  - Updated `Compare-CertificateIssuer` to use the new `Get-CertificateCommonName` function.
-  - Added check for X500 subject name in Get-TargetResource, which already exists in Test- and
-    Set-TargetResource - fixes [Issue #210](https://github.com/PowerShell/CertificateDsc/issues/210).
+  - Added `Get-CertificateCommonName` function as a fix for multiple
+    certificates being issued when having a third party CA which doesn't
+    format the Issuer CN in the same order as a MS CA - fixes [Issue #207](https://github.com/PowerShell/CertificateDsc/issues/207).
+  - Updated `Compare-CertificateIssuer` to use the new
+    `Get-CertificateCommonName` function.
+  - Added check for X500 subject name in Get-TargetResource, which already
+    exists in Test- and Set-TargetResource - fixes [Issue #210](https://github.com/PowerShell/CertificateDsc/issues/210).
 - Refactor integration tests to update to latest standards.
 - Refactor unit tests to update to latest standards.
 - CertificateImport:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
     being issued when having a third party CA which doesn't format the Issuer CN
     in the same order as a MS CA - fixes [Issue #207](https://github.com/PowerShell/CertificateDsc/issues/207).
   - Updated `Compare-CertificateIssuer` to use the new `Get-CertificateCommonName` function.
+  - Added check for X500 subject name in Get-TargetResource, which already exists in Test- and
+    Set-TargetResource - fixes [Issue #210](https://github.com/PowerShell/CertificateDsc/issues/210).
 - Refactor integration tests to update to latest standards.
 - Refactor unit tests to update to latest standards.
 - CertificateImport:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 - CertReq:
   - Fix error when ProviderName parameter is not encapsulated in
     double quotes - fixes [Issue #185](https://github.com/PowerShell/CertificateDsc/issues/185).
+  - Fix for multiple certificates being issued when having a third party CA which
+    doesn't format the Issuer CN in the same order as a MS CA - fixes
+    [Issue #207](https://github.com/PowerShell/CertificateDsc/issues/207).
 - Refactor integration tests to update to latest standards.
 - Refactor unit tests to update to latest standards.
 - CertificateImport:

--- a/DSCResources/MSFT_CertReq/MSFT_CertReq.psm1
+++ b/DSCResources/MSFT_CertReq/MSFT_CertReq.psm1
@@ -1101,7 +1101,7 @@ function Compare-CertificateIssuer
         $CARootName
     )
 
-    return ((Get-CertificateCommonName -DistinguishedName $Issuer) -eq "$CARootName")
+    return ((Get-CertificateCommonName -DistinguishedName $Issuer) -eq $CARootName)
 }
 
 <#
@@ -1153,5 +1153,7 @@ function Get-CertificateCommonName
         $DistinguishedName
     )
 
-    return ($DistinguishedName.split(',') | ForEach-Object {$_.TrimStart(' ')} | Where-Object {$_ -match 'CN='}).replace('CN=', '')
+    return ($DistinguishedName.split(',') |
+        ForEach-Object -Process { $_.TrimStart(' ') } |
+        Where-Object -FilterScript { $_ -match 'CN=' }).replace('CN=', '')
 }

--- a/DSCResources/MSFT_CertReq/MSFT_CertReq.psm1
+++ b/DSCResources/MSFT_CertReq/MSFT_CertReq.psm1
@@ -189,9 +189,15 @@ function Get-TargetResource
             $($script:localizedData.GettingCertReqStatusMessage -f $Subject, $CA)
         ) -join '' )
 
+    # If the Subject does not contain a full X500 path, construct just the CN
+    if (($Subject.split('=').Count) -eq 1)
+    {
+        $Subject = "CN=$Subject"
+    } # if
+
     $cert = Get-Childitem -Path Cert:\LocalMachine\My |
         Where-Object -FilterScript {
-            $_.Subject -eq "CN=$Subject" -and `
+            $_.Subject -eq $Subject -and `
             (Compare-CertificateIssuer -Issuer $_.Issuer -CARootName $CARootName)
     }
 

--- a/DSCResources/MSFT_CertReq/MSFT_CertReq.psm1
+++ b/DSCResources/MSFT_CertReq/MSFT_CertReq.psm1
@@ -208,9 +208,9 @@ function Get-TargetResource
             ) -join '' )
 
         $returnValue = @{
-            Subject             = $Cert.Subject.split(',')[0].replace('CN=', '')
+            Subject             = ($Cert.Subject.split(',') | ForEach-Object {$_.TrimStart(' ')} | Where-Object {$_ -match 'CN='}).replace('CN=', '')
             CAServerFQDN        = $caObject.CAServerFQDN
-            CARootName          = $Cert.Issuer.split(',')[0].replace('CN=', '')
+            CARootName          = ($Cert.Issuer.split(',') | ForEach-Object {$_.TrimStart(' ')} | Where-Object {$_ -match 'CN='}).replace('CN=', '')
             KeyLength           = $Cert.Publickey.Key.KeySize
             Exportable          = $Cert.PrivateKey.CspKeyContainerInfo.Exportable
             ProviderName        = $Cert.PrivateKey.CspKeyContainerInfo.ProviderName
@@ -1095,7 +1095,7 @@ function Compare-CertificateIssuer
         $CARootName
     )
 
-    return (($Issuer.split(',') | ForEach-Object {$_.TrimStart(' ')} | Where-Object{$_ -match 'CN='}) -eq "CN=$CARootName")
+    return (($Issuer.split(',') | ForEach-Object {$_.TrimStart(' ')} | Where-Object {$_ -match 'CN='}) -eq "CN=$CARootName")
 }
 
 <#

--- a/DSCResources/MSFT_CertReq/MSFT_CertReq.psm1
+++ b/DSCResources/MSFT_CertReq/MSFT_CertReq.psm1
@@ -1095,7 +1095,7 @@ function Compare-CertificateIssuer
         $CARootName
     )
 
-    return ($Issuer.split(',')[0] -eq "CN=$CARootName")
+    return (($Issuer.split(',') | %{$_.trimstart(' ')} | ?{$_ -match 'CN='}) -eq "CN=$CARootName")
 }
 
 <#

--- a/DSCResources/MSFT_CertReq/MSFT_CertReq.psm1
+++ b/DSCResources/MSFT_CertReq/MSFT_CertReq.psm1
@@ -208,9 +208,9 @@ function Get-TargetResource
             ) -join '' )
 
         $returnValue = @{
-            Subject             = ($Cert.Subject.split(',') | ForEach-Object {$_.TrimStart(' ')} | Where-Object {$_ -match 'CN='}).replace('CN=', '')
+            Subject             = Get-CertificateCommonName -DistinguishedName $Cert.Subject
             CAServerFQDN        = $caObject.CAServerFQDN
-            CARootName          = ($Cert.Issuer.split(',') | ForEach-Object {$_.TrimStart(' ')} | Where-Object {$_ -match 'CN='}).replace('CN=', '')
+            CARootName          = Get-CertificateCommonName -DistinguishedName $Cert.Issuer
             KeyLength           = $Cert.Publickey.Key.KeySize
             Exportable          = $Cert.PrivateKey.CspKeyContainerInfo.Exportable
             ProviderName        = $Cert.PrivateKey.CspKeyContainerInfo.ProviderName
@@ -1095,7 +1095,7 @@ function Compare-CertificateIssuer
         $CARootName
     )
 
-    return (($Issuer.split(',') | ForEach-Object {$_.TrimStart(' ')} | Where-Object {$_ -match 'CN='}) -eq "CN=$CARootName")
+    return ((Get-CertificateCommonName -DistinguishedName $Issuer) -eq "$CARootName")
 }
 
 <#
@@ -1126,4 +1126,26 @@ function ConvertTo-StringEnclosedInDoubleQuotes
     }
 
     return $Value
+}
+
+<#
+    .SYNOPSIS
+    Finds the Common Name in a X500 Distinguished Name.
+
+    .PARAMETER DistinguishedName
+    The X500 Distinguished Name.
+#>
+function Get-CertificateCommonName
+{
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [System.String]
+        $DistinguishedName
+    )
+
+    return ($DistinguishedName.split(',') | ForEach-Object {$_.TrimStart(' ')} | Where-Object {$_ -match 'CN='}).replace('CN=', '')
 }

--- a/DSCResources/MSFT_CertReq/MSFT_CertReq.psm1
+++ b/DSCResources/MSFT_CertReq/MSFT_CertReq.psm1
@@ -1095,7 +1095,7 @@ function Compare-CertificateIssuer
         $CARootName
     )
 
-    return (($Issuer.split(',') | %{$_.trimstart(' ')} | ?{$_ -match 'CN='}) -eq "CN=$CARootName")
+    return (($Issuer.split(',') | ForEach-Object {$_.TrimStart(' ')} | Where-Object{$_ -match 'CN='}) -eq "CN=$CARootName")
 }
 
 <#

--- a/Tests/Unit/MSFT_CertReq.Tests.ps1
+++ b/Tests/Unit/MSFT_CertReq.Tests.ps1
@@ -1849,6 +1849,22 @@ OID = $oid
                 }
             }
         }
+
+        Describe 'MSFT_CertReq\Get-CertificateCommonName' {
+            Context 'When called with certificate distinguished name with single X500 path' {
+                It 'Should return a string value containing only exactly the Common Name' {
+                    Get-CertificateCommonName `
+                        -DistinguishedName 'CN=xyz.contoso.com' | Should -BeExactly "xyz.contoso.com"
+                }
+            }
+
+            Context 'When called with certificate distinguished name with multiple X500 paths' {
+                It 'Should return a string value containing only exactly the Common Name' {
+                    Get-CertificateCommonName `
+                        -DistinguishedName 'CN=xyz.contoso.com, E=xyz@contoso.com, OU=Organisation Unit, O=Organisation, L=Locality, S=State, C=country' | Should -BeExactly "xyz.contoso.com"
+                }
+            }
+        }
     }
 }
 finally

--- a/Tests/Unit/MSFT_CertReq.Tests.ps1
+++ b/Tests/Unit/MSFT_CertReq.Tests.ps1
@@ -1820,7 +1820,7 @@ OID = $oid
             }
 
             Context 'When called with certificate issuer with multiple X500 paths not matching the CA root name' {
-                It 'Should return a true' {
+                It 'Should return a false' {
                     Compare-CertificateIssuer `
                         -Issuer 'CN=abc.contoso.com, E=xyz@contoso.com, OU=Organisation Unit, O=Organisation, L=Locality, S=State, C=country' `
                         -CARootName 'xyz.contoso.com' | Should -Be $false

--- a/Tests/Unit/MSFT_CertReq.Tests.ps1
+++ b/Tests/Unit/MSFT_CertReq.Tests.ps1
@@ -1864,6 +1864,13 @@ OID = $oid
                         -DistinguishedName 'CN=xyz.contoso.com, E=xyz@contoso.com, OU=Organisation Unit, O=Organisation, L=Locality, S=State, C=country' | Should -BeExactly "xyz.contoso.com"
                 }
             }
+
+            Context 'When called with certificate distinguished name with multiple X500 paths and CN at the end' {
+                It 'Should return a string value containing only exactly the Common Name' {
+                    Get-CertificateCommonName `
+                        -DistinguishedName 'E=xyz@contoso.com, OU=Organisation Unit, O=Organisation, L=Locality, S=State, C=country, CN=xyz.contoso.com' | Should -BeExactly "xyz.contoso.com"
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
#### Pull Request (PR) description
Removed hardcoded reference in Compare-CertificateIssuer and Get-TargetResource.
This should fix an issue with third party CA's/HSM's which does not necessarily format the CN in the same order as a Microsoft CA does. This issue caused the CA to issue a new cert each time DSC was run even though a valid certificate existed.

#### This Pull Request (PR) fixes the following issues
- Fixes #207 

#### Task list
- [x] Added an entry under the Unreleased section of the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in the resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/certificatedsc/209)
<!-- Reviewable:end -->
