### PR TITLE
CHANGELOG.MD and Minor Corrections - Fixes #211, #208

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+- Corrected incorrectly located entries in `CHANGELOG.MD`.
+- Fix bug `Find-Certificate` when invalid certificate path is passed - fixes
+  [Issue #208](https://github.com/PowerShell/CertificateDsc/issues/208).
+- CertReq:
+  - Added `Get-CertificateCommonName` function as a fix for multiple
+    certificates being issued when having a third party CA which doesn't
+    format the Issuer CN in the same order as a MS CA - fixes [Issue #207](https://github.com/PowerShell/CertificateDsc/issues/207).
+  - Updated `Compare-CertificateIssuer` to use the new
+    `Get-CertificateCommonName` function.
+  - Added check for X500 subject name in Get-TargetResource, which already
+    exists in Test- and Set-TargetResource - fixes [Issue #210](https://github.com/PowerShell/CertificateDsc/issues/210).
+  - Corrected name of working path to remove `x` - fixes [Issue #211](https://github.com/PowerShell/CertificateDsc/issues/211).
+
 ## 4.7.0.0
 
 - Opted into Common Tests 'Common Tests - Validate Localization' -
@@ -12,13 +25,6 @@
 - CertReq:
   - Fix error when ProviderName parameter is not encapsulated in
     double quotes - fixes [Issue #185](https://github.com/PowerShell/CertificateDsc/issues/185).
-  - Added `Get-CertificateCommonName` function as a fix for multiple
-    certificates being issued when having a third party CA which doesn't
-    format the Issuer CN in the same order as a MS CA - fixes [Issue #207](https://github.com/PowerShell/CertificateDsc/issues/207).
-  - Updated `Compare-CertificateIssuer` to use the new
-    `Get-CertificateCommonName` function.
-  - Added check for X500 subject name in Get-TargetResource, which already
-    exists in Test- and Set-TargetResource - fixes [Issue #210](https://github.com/PowerShell/CertificateDsc/issues/210).
 - Refactor integration tests to update to latest standards.
 - Refactor unit tests to update to latest standards.
 - CertificateImport:

--- a/DSCResources/MSFT_CertReq/MSFT_CertReq.psm1
+++ b/DSCResources/MSFT_CertReq/MSFT_CertReq.psm1
@@ -448,7 +448,7 @@ function Set-TargetResource
 
     # A unique identifier for temporary files that will be used when interacting with the command line utility
     $guid = [system.guid]::NewGuid().guid
-    $workingPath = Join-Path -Path $env:Temp -ChildPath "xCertReq-$guid"
+    $workingPath = Join-Path -Path $env:Temp -ChildPath "CertReq-$guid"
     $infPath = [System.IO.Path]::ChangeExtension($workingPath, '.inf')
     $reqPath = [System.IO.Path]::ChangeExtension($workingPath, '.req')
     $cerPath = [System.IO.Path]::ChangeExtension($workingPath, '.cer')

--- a/Modules/CertificateDsc.Common/CertificateDsc.Common.psm1
+++ b/Modules/CertificateDsc.Common/CertificateDsc.Common.psm1
@@ -741,7 +741,7 @@ function Find-Certificate
         # The Certificte Path is not valid
         New-InvalidArgumentException `
             -Message ($script:localizedData.CertificatePathError -f $certPath) `
-            -ArgumnentName 'Store'
+            -ArgumentName 'Store'
     } # if
 
     # Assemble the filter to use to select the certificate


### PR DESCRIPTION
#### Pull Request (PR) description

This PR corrects the CHANGELOG.MD and also fixes some minor problems:

- Corrected name of working path to remove `x` - fixes [Issue #211](https://github.com/PowerShell/CertificateDsc/issues/211).
- Fix bug `Find-Certificate` when invalid certificate path is passed - fixes
  [Issue #208](https://github.com/PowerShell/CertificateDsc/issues/208).

#### This Pull Request (PR) fixes the following issues
- Fixes #208
- Fixes #211

#### Task list

- [x] Added an entry under the Unreleased section of the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in the resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

@johlju - would you mind reviewing this? It should be a quick one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/certificatedsc/212)
<!-- Reviewable:end -->
