### PR TITLE
PfxImport: Use constructor instead of import method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `azure-pipelines.yml`
   - Remove `windows-2019` images fixes [#278](https://github.com/dsccommunity/CertificateDsc/issues/278).
   - Fix linting errors.
+### Fixed
 
+- Changed PFX certificate import to use X509Certificate2 constructor instead of the "Import" method. - Fixes [Issue #280](https://github.com/dsccommunity/CertificateDsc/issues/280).
 ## [6.0.0] - 2024-10-05
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `azure-pipelines.yml`
   - Remove `windows-2019` images fixes [#278](https://github.com/dsccommunity/CertificateDsc/issues/278).
   - Fix linting errors.
+
 ### Fixed
 
 - Changed PFX certificate import to use X509Certificate2 constructor instead of the "Import" method. - Fixes [Issue #280](https://github.com/dsccommunity/CertificateDsc/issues/280).
+
 ## [6.0.0] - 2024-10-05
 
 ### Changed

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -190,6 +190,43 @@ stages:
               testResultsFiles: '$(buildFolderName)/$(testResultFolderName)/NUnit*.xml'
               testRunTitle: 'Integration (Windows Server 2022)'
             condition: succeededOrFailed()
+            
+      - job: Test_Integration_2022_Core
+        displayName: 'Integration (Windows Server 2022, PowerShell Core)'
+        pool:
+          vmImage: 'windows-2022'
+        timeoutInMinutes: '0'
+        steps:
+          - task: DownloadPipelineArtifact@2
+            displayName: 'Download Pipeline Artifact'
+            inputs:
+              buildType: 'current'
+              artifactName: $(buildArtifactName)
+              targetPath: '$(Build.SourcesDirectory)/$(buildArtifactName)'
+
+          - task: PowerShell@2
+            name: configureWinRM
+            displayName: 'Configure WinRM'
+            inputs:
+              targetType: 'inline'
+              script: 'winrm quickconfig -quiet'
+              pwsh: true
+
+          - task: PowerShell@2
+            name: test
+            displayName: 'Run Integration Test'
+            inputs:
+              filePath: './build.ps1'
+              arguments: "-Tasks test -PesterScript 'tests/Integration' -CodeCoverageThreshold 0"
+              pwsh: true
+
+          - task: PublishTestResults@2
+            displayName: 'Publish Test Results'
+            inputs:
+              testResultsFormat: 'NUnit'
+              testResultsFiles: '$(buildFolderName)/$(testResultFolderName)/NUnit*.xml'
+              testRunTitle: 'Integration (Windows Server 2022, PowerShell Core)'
+            condition: succeededOrFailed()
 
       - job: Test_Unit_2025
         displayName: 'Unit (Windows Server 2025)'
@@ -223,7 +260,7 @@ stages:
       - job: Test_Integration_2025
         displayName: 'Integration (Windows Server 2025)'
         pool:
-          vmImage: 'windows-2022'
+          vmImage: 'windows-2025'
         timeoutInMinutes: '0'
         steps:
           - task: DownloadPipelineArtifact@2
@@ -255,6 +292,43 @@ stages:
               testResultsFormat: 'NUnit'
               testResultsFiles: '$(buildFolderName)/$(testResultFolderName)/NUnit*.xml'
               testRunTitle: 'Integration (Windows Server 2025)'
+            condition: succeededOrFailed()
+
+      - job: Test_Integration_2025_Core
+        displayName: 'Integration (Windows Server 2025, PowerShell Core)'
+        pool:
+          vmImage: 'windows-2025'
+        timeoutInMinutes: '0'
+        steps:
+          - task: DownloadPipelineArtifact@2
+            displayName: 'Download Pipeline Artifact'
+            inputs:
+              buildType: 'current'
+              artifactName: $(buildArtifactName)
+              targetPath: '$(Build.SourcesDirectory)/$(buildArtifactName)'
+
+          - task: PowerShell@2
+            name: configureWinRM
+            displayName: 'Configure WinRM'
+            inputs:
+              targetType: 'inline'
+              script: 'winrm quickconfig -quiet'
+              pwsh: true
+
+          - task: PowerShell@2
+            name: test
+            displayName: 'Run Integration Test'
+            inputs:
+              filePath: './build.ps1'
+              arguments: "-Tasks test -PesterScript 'tests/Integration' -CodeCoverageThreshold 0"
+              pwsh: true
+
+          - task: PublishTestResults@2
+            displayName: 'Publish Test Results'
+            inputs:
+              testResultsFormat: 'NUnit'
+              testResultsFiles: '$(buildFolderName)/$(testResultFolderName)/NUnit*.xml'
+              testRunTitle: 'Integration (Windows Server 2025, PowerShell Core)'
             condition: succeededOrFailed()
 
   - stage: Deploy

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -190,43 +190,6 @@ stages:
               testResultsFiles: '$(buildFolderName)/$(testResultFolderName)/NUnit*.xml'
               testRunTitle: 'Integration (Windows Server 2022)'
             condition: succeededOrFailed()
-            
-      - job: Test_Integration_2022_Core
-        displayName: 'Integration (Windows Server 2022, PowerShell Core)'
-        pool:
-          vmImage: 'windows-2022'
-        timeoutInMinutes: '0'
-        steps:
-          - task: DownloadPipelineArtifact@2
-            displayName: 'Download Pipeline Artifact'
-            inputs:
-              buildType: 'current'
-              artifactName: $(buildArtifactName)
-              targetPath: '$(Build.SourcesDirectory)/$(buildArtifactName)'
-
-          - task: PowerShell@2
-            name: configureWinRM
-            displayName: 'Configure WinRM'
-            inputs:
-              targetType: 'inline'
-              script: 'winrm quickconfig -quiet'
-              pwsh: true
-
-          - task: PowerShell@2
-            name: test
-            displayName: 'Run Integration Test'
-            inputs:
-              filePath: './build.ps1'
-              arguments: "-Tasks test -PesterScript 'tests/Integration' -CodeCoverageThreshold 0"
-              pwsh: true
-
-          - task: PublishTestResults@2
-            displayName: 'Publish Test Results'
-            inputs:
-              testResultsFormat: 'NUnit'
-              testResultsFiles: '$(buildFolderName)/$(testResultFolderName)/NUnit*.xml'
-              testRunTitle: 'Integration (Windows Server 2022, PowerShell Core)'
-            condition: succeededOrFailed()
 
       - job: Test_Unit_2025
         displayName: 'Unit (Windows Server 2025)'
@@ -260,7 +223,7 @@ stages:
       - job: Test_Integration_2025
         displayName: 'Integration (Windows Server 2025)'
         pool:
-          vmImage: 'windows-2025'
+          vmImage: 'windows-2022'
         timeoutInMinutes: '0'
         steps:
           - task: DownloadPipelineArtifact@2
@@ -292,43 +255,6 @@ stages:
               testResultsFormat: 'NUnit'
               testResultsFiles: '$(buildFolderName)/$(testResultFolderName)/NUnit*.xml'
               testRunTitle: 'Integration (Windows Server 2025)'
-            condition: succeededOrFailed()
-
-      - job: Test_Integration_2025_Core
-        displayName: 'Integration (Windows Server 2025, PowerShell Core)'
-        pool:
-          vmImage: 'windows-2025'
-        timeoutInMinutes: '0'
-        steps:
-          - task: DownloadPipelineArtifact@2
-            displayName: 'Download Pipeline Artifact'
-            inputs:
-              buildType: 'current'
-              artifactName: $(buildArtifactName)
-              targetPath: '$(Build.SourcesDirectory)/$(buildArtifactName)'
-
-          - task: PowerShell@2
-            name: configureWinRM
-            displayName: 'Configure WinRM'
-            inputs:
-              targetType: 'inline'
-              script: 'winrm quickconfig -quiet'
-              pwsh: true
-
-          - task: PowerShell@2
-            name: test
-            displayName: 'Run Integration Test'
-            inputs:
-              filePath: './build.ps1'
-              arguments: "-Tasks test -PesterScript 'tests/Integration' -CodeCoverageThreshold 0"
-              pwsh: true
-
-          - task: PublishTestResults@2
-            displayName: 'Publish Test Results'
-            inputs:
-              testResultsFormat: 'NUnit'
-              testResultsFiles: '$(buildFolderName)/$(testResultFolderName)/NUnit*.xml'
-              testRunTitle: 'Integration (Windows Server 2025, PowerShell Core)'
             condition: succeededOrFailed()
 
   - stage: Deploy

--- a/source/Modules/CertificateDsc.Common/CertificateDsc.Common.psm1
+++ b/source/Modules/CertificateDsc.Common/CertificateDsc.Common.psm1
@@ -1076,9 +1076,12 @@ function Import-PfxCertificateEx
 
     $certificatePassword = if ($Password) { $Password } else { [System.String]::Empty }
 
-    $cert = New-Object `
-        -TypeName System.Security.Cryptography.X509Certificates.X509Certificate2 `
-        -ArgumentList @($importDataValue, $certificatePassword, $flags)
+    $newObjectParameters = @{
+        TypeName     = 'System.Security.Cryptography.X509Certificates.X509Certificate2'
+        ArgumentList = @($importDataValue, $certificatePassword, $flags)
+    }
+
+    $cert = New-Object @newObjectParameters
 
     $certStore = New-Object `
         -TypeName System.Security.Cryptography.X509Certificates.X509Store `

--- a/source/Modules/CertificateDsc.Common/CertificateDsc.Common.psm1
+++ b/source/Modules/CertificateDsc.Common/CertificateDsc.Common.psm1
@@ -1075,17 +1075,16 @@ function Import-PfxCertificateEx
     }
 
     $certificatePassword = if ($Password) { $Password } else { [System.String]::Empty }
-
-    $newObjectParameters = @{
-        TypeName     = 'System.Security.Cryptography.X509Certificates.X509Certificate2'
-        ArgumentList = @($importDataValue, $certificatePassword, $flags)
-    }
-
-    $cert = New-Object @newObjectParameters
-
-    $certStore = New-Object `
-        -TypeName System.Security.Cryptography.X509Certificates.X509Store `
-        -ArgumentList @($store, $location)
+    $cert = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new(
+        $importDataValue,
+        $certificatePassword,
+        $flags
+    )
+    
+    $certStore = [System.Security.Cryptography.X509Certificates.X509Store]::new(
+        $store,
+        $location
+    )
 
     $certStore.Open('MaxAllowed')
     $certStore.Add($cert)

--- a/source/Modules/CertificateDsc.Common/CertificateDsc.Common.psm1
+++ b/source/Modules/CertificateDsc.Common/CertificateDsc.Common.psm1
@@ -1049,8 +1049,6 @@ function Import-PfxCertificateEx
     $location = Split-Path -Path (Split-Path -Path $CertStoreLocation -Parent) -Leaf
     $store = Split-Path -Path $CertStoreLocation -Leaf
 
-    $cert = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Certificate2
-
     $flags = [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::PersistKeySet
 
     if ($location -eq 'LocalMachine')
@@ -1076,14 +1074,11 @@ function Import-PfxCertificateEx
         $flags = $flags -bor [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::Exportable
     }
 
-    if ($Password)
-    {
-        $cert.Import($importDataValue, $Password, $flags)
-    }
-    else
-    {
-        $cert.Import($importDataValue, "", $flags)
-    }
+    $certificatePassword = if($Password) { $Password } else { [System.String]::Empty }
+
+    $cert = New-Object `
+        -TypeName System.Security.Cryptography.X509Certificates.X509Certificate2 `
+        -ArgumentList @($importDataValue, $certificatePassword, $flags)
 
     $certStore = New-Object `
         -TypeName System.Security.Cryptography.X509Certificates.X509Store `

--- a/source/Modules/CertificateDsc.Common/CertificateDsc.Common.psm1
+++ b/source/Modules/CertificateDsc.Common/CertificateDsc.Common.psm1
@@ -1074,13 +1074,20 @@ function Import-PfxCertificateEx
         $flags = $flags -bor [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::Exportable
     }
 
-    $certificatePassword = if ($Password) { $Password } else { [System.String]::Empty }
+    $certificatePassword = if ($Password)
+    {
+        $Password
+    }
+    else
+    {
+        [System.String]::Empty
+    }
     $cert = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new(
         $importDataValue,
         $certificatePassword,
         $flags
     )
-    
+
     $certStore = [System.Security.Cryptography.X509Certificates.X509Store]::new(
         $store,
         $location

--- a/source/Modules/CertificateDsc.Common/CertificateDsc.Common.psm1
+++ b/source/Modules/CertificateDsc.Common/CertificateDsc.Common.psm1
@@ -1074,7 +1074,7 @@ function Import-PfxCertificateEx
         $flags = $flags -bor [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::Exportable
     }
 
-    $certificatePassword = if($Password) { $Password } else { [System.String]::Empty }
+    $certificatePassword = if ($Password) { $Password } else { [System.String]::Empty }
 
     $cert = New-Object `
         -TypeName System.Security.Cryptography.X509Certificates.X509Certificate2 `


### PR DESCRIPTION
#### Pull Request (PR) description

Currently, the PfxImport module fails when using PowerShell 7 because the X509Certificate2 object is read only and therefore the "Import" method cannot be called on it. This PR resolves that issue by instead providing the certificate data in the constructor.

#### This Pull Request (PR) fixes the following issues

Fixes #280 

#### Task list


- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/CertificateDsc/281)
<!-- Reviewable:end -->
